### PR TITLE
Allow creation of "flat" modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
         "laminas/laminas-cli": "^1.1",
         "laminas/laminas-code": "^2.6.3 || ^3.3",
         "laminas/laminas-component-installer": "^2.0",
-        "laminas/laminas-composer-autoloading": "^2.0",
         "laminas/laminas-stdlib": "^3.1",
         "laminas/laminas-stratigility": "^3.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio": "^3.0",
-        "mezzio/mezzio-router": "^3.0"
+        "mezzio/mezzio-router": "^3.0",
+        "symfony/process": "^4.3 || ^5.1.2"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "467e6575c5e9cd8ebb9a5546264ef4cb",
+    "content-hash": "480704ad219a7317cdbdc0601b8e88be",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -347,74 +347,6 @@
                 }
             ],
             "time": "2021-05-10T19:40:40+00:00"
-        },
-        {
-            "name": "laminas/laminas-composer-autoloading",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-composer-autoloading.git",
-                "reference": "4267d3469df364d8375de1b675436031fd9756c4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-composer-autoloading/zipball/4267d3469df364d8375de1b675436031fd9756c4",
-                "reference": "4267d3469df364d8375de1b675436031fd9756c4",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-stdlib": "^3.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
-            },
-            "replace": {
-                "zfcampus/zf-composer-autoloading": "^2.1.0"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.1.4",
-                "mikey179/vfsstream": "^1.6.7",
-                "mockery/mockery": "^1.4.1",
-                "php-mock/php-mock-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-mockery": "^0.7.0",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "vimeo/psalm": "^4.6"
-            },
-            "bin": [
-                "bin/laminas-composer-autoloading"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\ComposerAutoloading\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Sets up Composer-based autoloading for your Laminas modules",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "autoloading",
-                "console",
-                "framework",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-composer-autoloading/issues",
-                "rss": "https://github.com/laminas/laminas-composer-autoloading/releases.atom",
-                "source": "https://github.com/laminas/laminas-composer-autoloading"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-03-22T22:28:12+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
@@ -1037,16 +969,16 @@
         },
         {
             "name": "mezzio/mezzio-router",
-            "version": "3.4.0",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-router.git",
-                "reference": "da7adc38450bc6db9ec583c0f3fa773f09bb02ce"
+                "reference": "f36f7149db1c17c0bdff86ddcfea66ae22b1737f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/da7adc38450bc6db9ec583c0f3fa773f09bb02ce",
-                "reference": "da7adc38450bc6db9ec583c0f3fa773f09bb02ce",
+                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/f36f7149db1c17c0bdff86ddcfea66ae22b1737f",
+                "reference": "f36f7149db1c17c0bdff86ddcfea66ae22b1737f",
                 "shasum": ""
             },
             "require": {
@@ -1054,15 +986,21 @@
                 "laminas/laminas-zendframework-bridge": "^1.0",
                 "php": "^7.3 || ~8.0.0",
                 "psr/container": "^1.0",
+                "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0.1",
-                "psr/http-server-middleware": "^1.0"
+                "psr/http-server-middleware": "^1.0",
+                "webmozart/assert": "^1.10"
+            },
+            "conflict": {
+                "mezzio/mezzio": "<3.5"
             },
             "replace": {
                 "zendframework/zend-expressive-router": "^3.1.1"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.1.0",
-                "malukenho/docheader": "^0.1.6",
+                "laminas/laminas-coding-standard": "~2.2.0",
+                "laminas/laminas-diactoros": "^2.6",
+                "laminas/laminas-stratigility": "^3.4",
                 "phpspec/prophecy": "^1.9",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.4.1",
@@ -1113,7 +1051,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-05-13T20:17:47+00:00"
+            "time": "2021-07-25T13:17:10+00:00"
         },
         {
             "name": "mezzio/mezzio-template",
@@ -1501,16 +1439,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.3.2",
+            "version": "v5.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1"
+                "reference": "ebd610dacd40d75b6a12bf64b5ccd494fc7d6ab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
-                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/ebd610dacd40d75b6a12bf64b5ccd494fc7d6ab1",
+                "reference": "ebd610dacd40d75b6a12bf64b5ccd494fc7d6ab1",
                 "shasum": ""
             },
             "require": {
@@ -1518,11 +1456,12 @@
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
-                "symfony/polyfill-php80": "^1.15",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/service-contracts": "^1.1|^2",
                 "symfony/string": "^5.1"
             },
             "conflict": {
+                "psr/log": ">=3",
                 "symfony/dependency-injection": "<4.4",
                 "symfony/dotenv": "<5.1",
                 "symfony/event-dispatcher": "<4.4",
@@ -1530,10 +1469,10 @@
                 "symfony/process": "<4.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0"
+                "psr/log-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
+                "psr/log": "^1|^2",
                 "symfony/config": "^4.4|^5.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
                 "symfony/event-dispatcher": "^4.4|^5.0",
@@ -1579,7 +1518,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.3.2"
+                "source": "https://github.com/symfony/console/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -1595,7 +1534,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-12T09:42:48+00:00"
+            "time": "2021-07-26T16:33:26+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1666,23 +1605,23 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.3.0",
+            "version": "v5.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "67a5f354afa8e2f231081b3fa11a5912f933c3ce"
+                "reference": "f2fd2208157553874560f3645d4594303058c4bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/67a5f354afa8e2f231081b3fa11a5912f933c3ce",
-                "reference": "67a5f354afa8e2f231081b3fa11a5912f933c3ce",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f2fd2208157553874560f3645d4594303058c4bd",
+                "reference": "f2fd2208157553874560f3645d4594303058c4bd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/event-dispatcher-contracts": "^2",
-                "symfony/polyfill-php80": "^1.15"
+                "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
                 "symfony/dependency-injection": "<4.4"
@@ -1692,7 +1631,7 @@
                 "symfony/event-dispatcher-implementation": "2.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
+                "psr/log": "^1|^2|^3",
                 "symfony/config": "^4.4|^5.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
                 "symfony/error-handler": "^4.4|^5.0",
@@ -1731,7 +1670,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.3.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -1747,7 +1686,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T17:43:10+00:00"
+            "time": "2021-07-23T15:55:36+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -2313,6 +2252,68 @@
                 }
             ],
             "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "d16634ee55b895bd85ec714dadc58e4428ecf030"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d16634ee55b895bd85ec714dadc58e4428ecf030",
+                "reference": "d16634ee55b895bd85ec714dadc58e4428ecf030",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-23T15:54:19+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3018,16 +3019,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.11.0",
+            "version": "v4.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94"
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/fe14cf3672a149364fb66dfe11bf6549af899f94",
-                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
                 "shasum": ""
             },
             "require": {
@@ -3068,22 +3069,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.11.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
             },
-            "time": "2021-07-03T13:36:55+00:00"
+            "time": "2021-07-21T10:44:31+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -3128,9 +3129,9 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2020-06-27T14:33:11+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
@@ -4019,16 +4020,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.6",
+            "version": "9.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb"
+                "reference": "d0dc8b6999c937616df4fb046792004b33fd31c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
-                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d0dc8b6999c937616df4fb046792004b33fd31c5",
+                "reference": "d0dc8b6999c937616df4fb046792004b33fd31c5",
                 "shasum": ""
             },
             "require": {
@@ -4106,7 +4107,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.7"
             },
             "funding": [
                 {
@@ -4118,7 +4119,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-23T05:14:38+00:00"
+            "time": "2021-07-19T06:14:47+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4973,6 +4974,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {
@@ -5203,20 +5205,21 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.3.0",
+            "version": "v5.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6"
+                "reference": "17f50e06018baec41551a71a15731287dbaab186"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
-                "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/17f50e06018baec41551a71a15731287dbaab186",
+                "reference": "17f50e06018baec41551a71a15731287dbaab186",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5"
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
             "autoload": {
@@ -5244,7 +5247,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.3.0"
+                "source": "https://github.com/symfony/finder/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -5260,7 +5263,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T12:52:38+00:00"
+            "time": "2021-07-23T15:54:19+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Composer/ComposerFileException.php
+++ b/src/Composer/ComposerFileException.php
@@ -6,6 +6,8 @@ namespace Mezzio\Tooling\Composer;
 
 use RuntimeException;
 
+use function sprintf;
+
 class ComposerFileException extends RuntimeException
 {
     public static function dueToMissingFile(string $filename): self

--- a/src/Composer/ComposerFileException.php
+++ b/src/Composer/ComposerFileException.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Composer;
+
+use RuntimeException;
+
+class ComposerFileException extends RuntimeException
+{
+    public static function dueToMissingFile(string $filename): self
+    {
+        return new self(sprintf(
+            'Unable to open "%s"; file does not exist',
+            $filename
+        ));
+    }
+
+    public static function dueToPermissions(string $filename): self
+    {
+        return new self(sprintf(
+            'Unable to open "%s"; lacking read permissions',
+            $filename
+        ));
+    }
+
+    public static function dueToMissingDirectory(string $directory): self
+    {
+        return new self(sprintf(
+            'Unable to write composer.json; directory "%s" does not exist',
+            $directory
+        ));
+    }
+
+    public static function dueToDirectoryPermissions(string $directory): self
+    {
+        return new self(sprintf(
+            'Unable to write composer.json; lacking permissions to write to directory "%s"',
+            $directory
+        ));
+    }
+}

--- a/src/Composer/ComposerPackageFactoryInterface.php
+++ b/src/Composer/ComposerPackageFactoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Composer;
+
+interface ComposerPackageFactoryInterface
+{
+    public function loadPackage(string $projectRoot): ComposerPackageInterface;
+}

--- a/src/Composer/ComposerPackageInterface.php
+++ b/src/Composer/ComposerPackageInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Composer;
+
+interface ComposerPackageInterface
+{
+    /**
+     * Add a PSR-4 autoloading rule to the project package.
+     *
+     * A "true" return value indicates an update was made.
+     */
+    public function addPsr4AutoloadRule(string $namespace, string $path, bool $isDev = false): bool;
+
+    /**
+     * Remove a PSR-4 autoloading rule from the project package.
+     *
+     * A "true" return value indicates an update was made.
+     */
+    public function removePsr4AutoloadRule(string $namespace, bool $isDev = false): bool;
+}

--- a/src/Composer/ComposerProcessFactoryInterface.php
+++ b/src/Composer/ComposerProcessFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Composer;
+
+interface ComposerProcessFactoryInterface
+{
+    /**
+     * @param string[] $args List of CLI arguments to run
+     */
+    public function createProcess(array $args): ComposerProcessInterface;
+}

--- a/src/Composer/ComposerProcessInterface.php
+++ b/src/Composer/ComposerProcessInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Composer;
+
+interface ComposerProcessInterface
+{
+    public function run(): ComposerProcessResultInterface;
+}

--- a/src/Composer/ComposerProcessResultInterface.php
+++ b/src/Composer/ComposerProcessResultInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Composer;
+
+interface ComposerProcessResultInterface
+{
+    public function isSuccessful(): bool;
+
+    public function getOutput(): string;
+
+    public function getErrorOutput(): string;
+}

--- a/src/Composer/ComposerProcessResultViaSymfonyProcess.php
+++ b/src/Composer/ComposerProcessResultViaSymfonyProcess.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Composer;
+
+use Symfony\Component\Process\Process;
+
+final class ComposerProcessResultViaSymfonyProcess implements ComposerProcessResultInterface
+{
+    /** @var Process */
+    private $process;
+
+    public function __construct(Process $process)
+    {
+        $this->process = $process;
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->process->isSuccessful();
+    }
+
+    public function getOutput(): string
+    {
+        return $this->process->getOutput();
+    }
+
+    public function getErrorOutput(): string
+    {
+        return $this->process->getErrorOutput();
+    }
+}

--- a/src/Composer/ComposerProcessViaSymfonyProcess.php
+++ b/src/Composer/ComposerProcessViaSymfonyProcess.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Composer;
+
+use Symfony\Component\Process\Process;
+
+/** @internal */
+class ComposerProcessViaSymfonyProcess implements ComposerProcessInterface
+{
+    /** @var Process */
+    private $process;
+
+    public function __construct(Process $process)
+    {
+        $this->process = $process;
+    }
+
+    public function run(): ComposerProcessResultInterface
+    {
+        $this->process->run();
+        return new ComposerProcessResultViaSymfonyProcess($this->process);
+    }
+}

--- a/src/Composer/ComposerProcessViaSymfonyProcessFactory.php
+++ b/src/Composer/ComposerProcessViaSymfonyProcessFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Composer;
+
+use Symfony\Component\Process\Process;
+
+final class ComposerProcessViaSymfonyProcessFactory implements ComposerProcessFactoryInterface
+{
+    public function createProcess(array $args): ComposerProcessInterface
+    {
+        return new ComposerProcessViaSymfonyProcess(
+            new Process($args)
+        );
+    }
+}

--- a/src/Composer/FileSystemBasedComposerPackage.php
+++ b/src/Composer/FileSystemBasedComposerPackage.php
@@ -4,6 +4,23 @@ declare(strict_types=1);
 
 namespace Mezzio\Tooling\Composer;
 
+use function dirname;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function is_dir;
+use function is_readable;
+use function is_writable;
+use function json_decode;
+use function json_encode;
+use function rtrim;
+use function sprintf;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
 final class FileSystemBasedComposerPackage implements ComposerPackageInterface
 {
     /** @var string */

--- a/src/Composer/FileSystemBasedComposerPackage.php
+++ b/src/Composer/FileSystemBasedComposerPackage.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Composer;
+
+final class FileSystemBasedComposerPackage implements ComposerPackageInterface
+{
+    /** @var string */
+    private $composerFile;
+
+    public function __construct(string $projectRoot)
+    {
+        $this->composerFile = sprintf('%s/composer.json', $projectRoot);
+    }
+
+    public function addPsr4AutoloadRule(string $namespace, string $path, bool $isDev = false): bool
+    {
+        $namespace = rtrim($namespace, '\\') . '\\';
+        $path      = rtrim($path, '/\\') . '/';
+        $key       = $isDev ? 'autoload-dev' : 'autoload';
+        $package   = $this->parse();
+
+        if (isset($package[$key]['psr-4'][$namespace])) {
+            // Nothing to do; a rule already exists
+            return false;
+        }
+
+        $package[$key]['psr-4'][$namespace] = $path;
+        $this->write($package);
+
+        return true;
+    }
+
+    public function removePsr4AutoloadRule(string $namespace, bool $isDev = false): bool
+    {
+        $namespace = rtrim($namespace, '\\') . '\\';
+        $key       = $isDev ? 'autoload-dev' : 'autoload';
+        $package   = $this->parse();
+
+        if (! isset($package[$key]['psr-4'][$namespace])) {
+            // Nothing to do; no rule exists
+            return false;
+        }
+
+        unset($package[$key]['psr-4'][$namespace]);
+        $this->write($package);
+
+        return true;
+    }
+
+    private function parse(): array
+    {
+        if (! file_exists($this->composerFile)) {
+            return [];
+        }
+
+        if (! is_readable($this->composerFile)) {
+            throw ComposerFileException::dueToPermissions($this->composerFile);
+        }
+
+        $contents = file_get_contents($this->composerFile);
+        return json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    private function write(array $package): void
+    {
+        $path = dirname($this->composerFile);
+        if (! is_dir($path)) {
+            throw ComposerFileException::dueToMissingDirectory($path);
+        }
+
+        if (! is_writable($path)) {
+            throw ComposerFileException::dueToDirectoryPermissions($path);
+        }
+
+        $contents = json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        file_put_contents($this->composerFile, $contents . "\n");
+    }
+}

--- a/src/Composer/FileSystemBasedComposerPackageFactory.php
+++ b/src/Composer/FileSystemBasedComposerPackageFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Composer;
+
+final class FileSystemBasedComposerPackageFactory implements ComposerPackageFactoryInterface
+{
+    public function loadPackage(string $projectRoot): ComposerPackageInterface
+    {
+        return new FileSystemBasedComposerPackage($projectRoot);
+    }
+}

--- a/src/Module/DeregisterCommand.php
+++ b/src/Module/DeregisterCommand.php
@@ -68,8 +68,8 @@ final class DeregisterCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $module      = $input->getArgument('module');
-        $composer    = $input->getOption('composer') ?: 'composer';
+        $module   = $input->getArgument('module');
+        $composer = $input->getOption('composer') ?: 'composer';
 
         $injector       = new ConfigAggregatorInjector($this->projectRoot);
         $configProvider = sprintf('%s\ConfigProvider', $module);
@@ -80,7 +80,7 @@ final class DeregisterCommand extends Command
         // If no updates are made to autoloading, no need to update the autoloader.
         // Additionally, since this command deregisters the module with the
         // application, it can NEVER be a dev autoloading rule.
-        if (!  $this->package->removePsr4AutoloadRule($module, false)) {
+        if (! $this->package->removePsr4AutoloadRule($module, false)) {
             $output->writeln(sprintf('Removed config provider for module %s', $module));
             return 0;
         }

--- a/src/Module/DeregisterCommandFactory.php
+++ b/src/Module/DeregisterCommandFactory.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Mezzio\Tooling\Module;
 
+use Mezzio\Tooling\Composer\ComposerProcessViaSymfonyProcessFactory;
+use Mezzio\Tooling\Composer\FileSystemBasedComposerPackageFactory;
+
 use function getcwd;
 use function realpath;
 
@@ -11,6 +14,10 @@ final class DeregisterCommandFactory
 {
     public function __invoke(): DeregisterCommand
     {
-        return new DeregisterCommand(realpath(getcwd()));
+        return new DeregisterCommand(
+            realpath(getcwd()),
+            new FileSystemBasedComposerPackageFactory(),
+            new ComposerProcessViaSymfonyProcessFactory()
+        );
     }
 }

--- a/src/Module/ModuleMetadata.php
+++ b/src/Module/ModuleMetadata.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Module;
+
+final class ModuleMetadata
+{
+    /** @var string */
+    private $name;
+
+    /** @var string */
+    private $rootPath;
+
+    /** @var string */
+    private $sourcePath;
+
+    public function __construct(
+        string $name,
+        string $rootPath,
+        string $sourcePath
+    ) {
+        $this->name       = $name;
+        $this->rootPath   = $rootPath;
+        $this->sourcePath = $sourcePath;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function rootPath(): string
+    {
+        return $this->rootPath;
+    }
+
+    public function sourcePath(): string
+    {
+        return $this->sourcePath;
+    }
+}

--- a/src/Module/RegisterCommand.php
+++ b/src/Module/RegisterCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function is_dir;
 use function sprintf;
 
 final class RegisterCommand extends Command
@@ -43,8 +44,7 @@ final class RegisterCommand extends Command
         string $projectRoot,
         ComposerPackageFactoryInterface $packageFactory,
         ComposerProcessFactoryInterface $processFactory
-    )
-    {
+    ) {
         $this->projectRoot    = $projectRoot;
         $this->package        = $packageFactory->loadPackage($projectRoot);
         $this->processFactory = $processFactory;
@@ -82,7 +82,7 @@ final class RegisterCommand extends Command
         // If no updates are made to autoloading, no need to update the autoloader.
         // Additionally, since this command registers the module with the
         // application, it can NEVER be a dev autoloading rule.
-        if (!  $this->package->addPsr4AutoloadRule($module, $modulePath, false)) {
+        if (! $this->package->addPsr4AutoloadRule($module, $modulePath, false)) {
             $output->writeln(sprintf('Registered config provider for module %s', $module));
             return 0;
         }

--- a/src/Module/RegisterCommand.php
+++ b/src/Module/RegisterCommand.php
@@ -6,7 +6,8 @@ namespace Mezzio\Tooling\Module;
 
 use Laminas\ComponentInstaller\Injector\ConfigAggregatorInjector;
 use Laminas\ComponentInstaller\Injector\InjectorInterface;
-use Laminas\ComposerAutoloading\Command\Enable;
+use Mezzio\Tooling\Composer\ComposerPackageFactoryInterface;
+use Mezzio\Tooling\Composer\ComposerProcessFactoryInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,12 +30,24 @@ final class RegisterCommand extends Command
     /** @var null|string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:module:register';
 
+    /** @var ComposerPackageInterface */
+    private $package;
+
     /** @var string */
     private $projectRoot;
 
-    public function __construct(string $projectRoot)
+    /** @var ComposerProcessFactoryInterface */
+    private $processFactory;
+
+    public function __construct(
+        string $projectRoot,
+        ComposerPackageFactoryInterface $packageFactory,
+        ComposerProcessFactoryInterface $processFactory
+    )
     {
-        $this->projectRoot = $projectRoot;
+        $this->projectRoot    = $projectRoot;
+        $this->package        = $packageFactory->loadPackage($projectRoot);
+        $this->processFactory = $processFactory;
 
         parent::__construct();
     }
@@ -64,11 +77,39 @@ final class RegisterCommand extends Command
             );
         }
 
-        $enable = new Enable($this->projectRoot, $modulesPath, $composer);
-        $enable->setMoveModuleClass(false);
-        $enable->process($module);
+        $modulePath = $this->detectModuleSourcePath($modulesPath, $module);
 
-        $output->writeln(sprintf('Registered autoloading rules and added configuration entry for module %s', $module));
+        // If no updates are made to autoloading, no need to update the autoloader.
+        // Additionally, since this command registers the module with the
+        // application, it can NEVER be a dev autoloading rule.
+        if (!  $this->package->addPsr4AutoloadRule($module, $modulePath, false)) {
+            $output->writeln(sprintf('Registered config provider for module %s', $module));
+            return 0;
+        }
+
+        $result = $this->processFactory->createProcess([$composer, 'dump-autoload'])->run();
+        if (! $result->isSuccessful()) {
+            $output->writeln('<error>Unable to dump autoloader rules</error>');
+            $output->writeln(sprintf('Command "%s dump-autoload": %s', $composer, $result->getErrorOutput()));
+            return 1;
+        }
+
+        $output->writeln(sprintf('Registered config provider and autoloading rules for module %s', $module));
         return 0;
+    }
+
+    private function detectModuleSourcePath(string $sourcePath, string $module): string
+    {
+        $modulePath    = sprintf('%s/%s', $sourcePath, $module);
+        $canonicalPath = sprintf('%s/%s', $this->projectRoot, $modulePath);
+
+        if (! is_dir($canonicalPath)) {
+            throw new RuntimeException(sprintf('Cannot register module; directory "%s" does not exist', $modulePath));
+        }
+
+        $nestedSourcePath = $modulePath . '/src';
+        $canonicalPath    = sprintf('%s/%s', $this->projectRoot, $nestedSourcePath);
+
+        return is_dir($canonicalPath) ? $nestedSourcePath : $modulePath;
     }
 }

--- a/src/Module/RegisterCommandFactory.php
+++ b/src/Module/RegisterCommandFactory.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Mezzio\Tooling\Module;
 
+use Mezzio\Tooling\Composer\ComposerProcessViaSymfonyProcessFactory;
+use Mezzio\Tooling\Composer\FileSystemBasedComposerPackageFactory;
+
 use function getcwd;
 use function realpath;
 
@@ -11,6 +14,10 @@ final class RegisterCommandFactory
 {
     public function __invoke(): RegisterCommand
     {
-        return new RegisterCommand(realpath(getcwd()));
+        return new RegisterCommand(
+            realpath(getcwd()),
+            new FileSystemBasedComposerPackageFactory(),
+            new ComposerProcessViaSymfonyProcessFactory()
+        );
     }
 }

--- a/src/TemplateResolutionTrait.php
+++ b/src/TemplateResolutionTrait.php
@@ -7,7 +7,6 @@ namespace Mezzio\Tooling;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerInterface;
 
-use function get_class;
 use function preg_replace;
 use function strpos;
 use function strrpos;
@@ -90,6 +89,6 @@ trait TemplateResolutionTrait
             return null;
         }
         $renderer = $container->get(TemplateRendererInterface::class);
-        return get_class($renderer);
+        return $renderer::class;
     }
 }

--- a/src/TemplateResolutionTrait.php
+++ b/src/TemplateResolutionTrait.php
@@ -7,6 +7,7 @@ namespace Mezzio\Tooling;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerInterface;
 
+use function get_class;
 use function preg_replace;
 use function strpos;
 use function strrpos;
@@ -89,6 +90,6 @@ trait TemplateResolutionTrait
             return null;
         }
         $renderer = $container->get(TemplateRendererInterface::class);
-        return $renderer::class;
+        return get_class($renderer);
     }
 }

--- a/test/Composer/FileSystemBasedComposerPackageTest.php
+++ b/test/Composer/FileSystemBasedComposerPackageTest.php
@@ -7,6 +7,17 @@ namespace MezzioTest\Tooling\Composer;
 use Mezzio\Tooling\Composer\FileSystemBasedComposerPackage;
 use PHPUnit\Framework\TestCase;
 
+use function copy;
+use function file_exists;
+use function file_get_contents;
+use function json_decode;
+use function rtrim;
+use function sprintf;
+use function unlink;
+use function var_export;
+
+use const JSON_THROW_ON_ERROR;
+
 class FileSystemBasedComposerPackageTest extends TestCase
 {
     public function setUp(): void
@@ -67,8 +78,8 @@ class FileSystemBasedComposerPackageTest extends TestCase
         $package   = $this->getComposerJson($composerJsonFile);
         $key       = $isDev ? 'autoload-dev' : 'autoload';
 
-        $value     = $package[$key]['psr-4'][$namespace] ?? null;
-        $message   = $message ?: sprintf(
+        $value   = $package[$key]['psr-4'][$namespace] ?? null;
+        $message = $message ?: sprintf(
             'Expected to find path "%s" registered for namespace "%s"; received "%s"',
             $path,
             $namespace,
@@ -93,7 +104,7 @@ class FileSystemBasedComposerPackageTest extends TestCase
         $package   = $this->getComposerJson($composerJsonFile);
         $key       = $isDev ? 'autoload-dev' : 'autoload';
 
-        $message   = $message ?: sprintf(
+        $message = $message ?: sprintf(
             'Did NOT expect to find "%s" rule registered for namespace "%s"; received "%s"',
             $key,
             $namespace,

--- a/test/Composer/FileSystemBasedComposerPackageTest.php
+++ b/test/Composer/FileSystemBasedComposerPackageTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Tooling\Composer;
+
+use Mezzio\Tooling\Composer\FileSystemBasedComposerPackage;
+use PHPUnit\Framework\TestCase;
+
+class FileSystemBasedComposerPackageTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->tearDownAssets();
+    }
+
+    public function tearDown(): void
+    {
+        $this->tearDownAssets();
+    }
+
+    public function tearDownAssets(): void
+    {
+        $assetDirectories = [
+            __DIR__ . '/TestAsset/rule-exists',
+            __DIR__ . '/TestAsset/rule-does-not-exist',
+            __DIR__ . '/TestAsset/composer-file-does-not-exist',
+        ];
+
+        foreach ($assetDirectories as $dir) {
+            $file = $dir . '/composer.json';
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
+
+    public function copyDistAsset(string $path): string
+    {
+        $path   = __DIR__ . '/TestAsset/' . $path;
+        $source = $path . '/composer.json.dist';
+        $target = $path . '/composer.json';
+        if (! file_exists($source)) {
+            return $path;
+        }
+
+        copy($source, $target);
+        return $path;
+    }
+
+    public function getComposerJson(string $filename): array
+    {
+        $json = file_get_contents($filename);
+        return json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    public function assertAutoloadRuleExists(
+        string $namespace,
+        string $path,
+        bool $isDev,
+        string $composerJsonFile,
+        ?string $message = null,
+        bool $provideComposerDetails = false
+    ): void {
+        $namespace = rtrim($namespace, '\\') . '\\';
+        $path      = rtrim($path, '/') . '/';
+        $package   = $this->getComposerJson($composerJsonFile);
+        $key       = $isDev ? 'autoload-dev' : 'autoload';
+
+        $value     = $package[$key]['psr-4'][$namespace] ?? null;
+        $message   = $message ?: sprintf(
+            'Expected to find path "%s" registered for namespace "%s"; received "%s"',
+            $path,
+            $namespace,
+            var_export($value, true)
+        );
+
+        if ($provideComposerDetails) {
+            $message .= "\n" . var_export($package, true);
+        }
+
+        self::assertSame($path, $value, $message);
+    }
+
+    public function assertAutoloadRuleDoesNotExist(
+        string $namespace,
+        bool $isDev,
+        string $composerJsonFile,
+        ?string $message = null,
+        bool $provideComposerDetails = false
+    ): void {
+        $namespace = rtrim($namespace, '\\') . '\\';
+        $package   = $this->getComposerJson($composerJsonFile);
+        $key       = $isDev ? 'autoload-dev' : 'autoload';
+
+        $message   = $message ?: sprintf(
+            'Did NOT expect to find "%s" rule registered for namespace "%s"; received "%s"',
+            $key,
+            $namespace,
+            var_export($package[$key]['psr-4'][$namespace] ?? '', true)
+        );
+
+        if ($provideComposerDetails) {
+            $message .= "\n" . var_export($package, true);
+        }
+
+        if (! isset($package[$key]['psr-4'])) {
+            return;
+        }
+
+        self::assertArrayNotHasKey($namespace, $package[$key]['psr-4'], $message);
+    }
+
+    public function addRuleProvider(): array
+    {
+        return [
+            'production rule for recommended structure' => [false, 'TestModule', 'src/TestModule/src'],
+            'dev rule for recommended structure'        => [true,  'TestModule', 'src/TestModule/src'],
+            'production rule for flat structure'        => [false, 'TestModule', 'src/TestModule'],
+            'dev rule for flat structure'               => [true,  'TestModule', 'src/TestModule'],
+        ];
+    }
+
+    /** @dataProvider addRuleProvider */
+    public function testCanAddRule(bool $isDev, string $module, string $moduleSourcePath): void
+    {
+        $projectRoot = $this->copyDistAsset('rule-does-not-exist');
+        $package     = new FileSystemBasedComposerPackage($projectRoot);
+        $package->addPsr4AutoloadRule($module, $moduleSourcePath, $isDev);
+
+        $this->assertAutoloadRuleExists($module, $moduleSourcePath, $isDev, $projectRoot . '/composer.json');
+    }
+
+    public function removeRuleProvider(): array
+    {
+        return [
+            'production rule' => [false, 'TestModule', 'rule-exists', 'autoload'],
+            'dev rule'        => [true,  'TestModule', 'rule-exists-dev', 'autoload-dev'],
+        ];
+    }
+
+    /** @dataProvider removeRuleProvider */
+    public function testCanRemoveRule(bool $isDev, string $module, string $assetDir, string $autoloadKey): void
+    {
+        $projectRoot = $this->copyDistAsset($assetDir);
+        $package     = new FileSystemBasedComposerPackage($projectRoot);
+        $package->removePsr4AutoloadRule($module, $isDev);
+
+        $this->assertAutoloadRuleDoesNotExist($module, $isDev, $projectRoot . '/composer.json');
+    }
+
+    public function testDoesNotAddRuleIfRuleExists(): void
+    {
+        $module      = 'TestModule';
+        $projectRoot = $this->copyDistAsset('rule-exists');
+        $package     = new FileSystemBasedComposerPackage($projectRoot);
+        $package->addPsr4AutoloadRule($module, 'library/modules/TestModule');
+
+        $this->assertAutoloadRuleExists($module, 'src/TestModule/', false, $projectRoot . '/composer.json');
+    }
+
+    public function testRemovalDoesNotChangePackageIfRuleDoesNotExist(): void
+    {
+        $module      = 'TestUncreatedModule';
+        $projectRoot = $this->copyDistAsset('rule-exists');
+        $package     = new FileSystemBasedComposerPackage($projectRoot);
+        $package->removePsr4AutoloadRule($module);
+
+        $this->assertAutoloadRuleExists('TestModule', 'src/TestModule/', false, $projectRoot . '/composer.json');
+        $this->assertAutoloadRuleDoesNotExist($module, false, $projectRoot . '/composer.json');
+    }
+}

--- a/test/Composer/TestAsset/composer-file-does-not-exist/.gitignore
+++ b/test/Composer/TestAsset/composer-file-does-not-exist/.gitignore
@@ -1,0 +1,1 @@
+composer.json

--- a/test/Composer/TestAsset/rule-does-not-exist/.gitignore
+++ b/test/Composer/TestAsset/rule-does-not-exist/.gitignore
@@ -1,0 +1,1 @@
+composer.json

--- a/test/Composer/TestAsset/rule-does-not-exist/composer.json.dist
+++ b/test/Composer/TestAsset/rule-does-not-exist/composer.json.dist
@@ -1,0 +1,10 @@
+{
+    "autoload": {
+        "psr-4": {
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+        }
+    }
+}

--- a/test/Composer/TestAsset/rule-exists-dev/.gitignore
+++ b/test/Composer/TestAsset/rule-exists-dev/.gitignore
@@ -1,0 +1,1 @@
+composer.json

--- a/test/Composer/TestAsset/rule-exists-dev/composer.json.dist
+++ b/test/Composer/TestAsset/rule-exists-dev/composer.json.dist
@@ -1,0 +1,7 @@
+{
+    "autoload-dev": {
+        "psr-4": {
+            "TestModule\\": "src/TestModule/"
+        }
+    }
+}

--- a/test/Composer/TestAsset/rule-exists/.gitignore
+++ b/test/Composer/TestAsset/rule-exists/.gitignore
@@ -1,0 +1,1 @@
+composer.json

--- a/test/Composer/TestAsset/rule-exists/composer.json.dist
+++ b/test/Composer/TestAsset/rule-exists/composer.json.dist
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-4": {
+            "TestModule\\": "src/TestModule/"
+        }
+    }
+}

--- a/test/Module/CreateCommandTest.php
+++ b/test/Module/CreateCommandTest.php
@@ -160,7 +160,7 @@ class CreateCommandTest extends TestCase
      */
     public function testCommandEmitsExpectedSuccessMessages(bool $configAsArrayObject)
     {
-        $metadata = new ModuleMetadata(
+        $metadata    = new ModuleMetadata(
             'Foo',
             './library/modules',
             './library/modules/Foo/src'
@@ -207,7 +207,7 @@ class CreateCommandTest extends TestCase
      */
     public function testCommandWillFailIfRegisterFails(bool $configAsArrayObject)
     {
-        $metadata = new ModuleMetadata(
+        $metadata    = new ModuleMetadata(
             'Foo',
             './library/modules',
             './library/modules/Foo/src'
@@ -287,7 +287,7 @@ class CreateCommandTest extends TestCase
      */
     public function testCommandPassesFlatOptionDuringCreation(bool $configAsArrayObject): void
     {
-        $metadata = new ModuleMetadata(
+        $metadata    = new ModuleMetadata(
             'Foo',
             './library/modules',
             './library/modules/Foo'

--- a/test/Module/CreateTest.php
+++ b/test/Module/CreateTest.php
@@ -109,16 +109,15 @@ class CreateTest extends TestCase
     public function testCreatesConfigProvider()
     {
         $configProvider = vfsStream::url('project/my-modules/MyApp/src/ConfigProvider.php');
-        self::assertEquals(
-            sprintf('Created module MyApp in %s/MyApp', $this->modulesDir->url()),
-            $this->command->process('MyApp', $this->modulesPath, $this->projectDir)
-        );
+        $metadata       = $this->command->process('MyApp', $this->modulesPath, $this->projectDir);
+
+        self::assertEquals(sprintf('%s/MyApp', $this->modulesDir->url()), $metadata->rootPath());
         self::assertFileExists($configProvider);
         $configProviderContent = file_get_contents($configProvider);
         self::assertSame(1, preg_match('/\bnamespace MyApp\b/', $configProviderContent));
         self::assertSame(1, preg_match('/\bclass ConfigProvider\b/', $configProviderContent));
         $command         = $this->command;
-        $expectedContent = sprintf($command::TEMPLATE_CONFIG_PROVIDER, 'MyApp', 'my-app');
+        $expectedContent = sprintf($command::TEMPLATE_CONFIG_PROVIDER_RECOMMENDED, 'MyApp', 'my-app');
         self::assertSame($expectedContent, $configProviderContent);
     }
 
@@ -128,7 +127,7 @@ class CreateTest extends TestCase
         $configProvider        = vfsStream::url('project/my-modules/My2App/src/ConfigProvider.php');
         $configProviderContent = file_get_contents($configProvider);
         $command               = $this->command;
-        $expectedContent       = sprintf($command::TEMPLATE_CONFIG_PROVIDER, 'My2App', 'my2-app');
+        $expectedContent       = sprintf($command::TEMPLATE_CONFIG_PROVIDER_RECOMMENDED, 'My2App', 'my2-app');
         self::assertSame($expectedContent, $configProviderContent);
     }
 
@@ -138,7 +137,22 @@ class CreateTest extends TestCase
         $configProvider        = vfsStream::url('project/my-modules/THEApp/src/ConfigProvider.php');
         $configProviderContent = file_get_contents($configProvider);
         $command               = $this->command;
-        $expectedContent       = sprintf($command::TEMPLATE_CONFIG_PROVIDER, 'THEApp', 'the-app');
+        $expectedContent       = sprintf($command::TEMPLATE_CONFIG_PROVIDER_RECOMMENDED, 'THEApp', 'the-app');
+        self::assertSame($expectedContent, $configProviderContent);
+    }
+
+    public function testCanCreateFlatStructureWhenRequested(): void
+    {
+        $command  = new Create(true);
+        $metadata = $command->process('MyApp', $this->modulesPath, $this->projectDir);
+
+        $expectedPaths = sprintf('%s/MyApp', $this->modulesDir->url());
+        self::assertEquals($expectedPaths, $metadata->rootPath());
+        self::assertEquals($expectedPaths, $metadata->sourcePath());
+
+        $configProvider        = vfsStream::url('project/my-modules/MyApp/ConfigProvider.php');
+        $configProviderContent = file_get_contents($configProvider);
+        $expectedContent       = sprintf($command::TEMPLATE_CONFIG_PROVIDER_FLAT, 'MyApp');
         self::assertSame($expectedContent, $configProviderContent);
     }
 }

--- a/test/Module/DeregisterCommandTest.php
+++ b/test/Module/DeregisterCommandTest.php
@@ -63,9 +63,9 @@ class DeregisterCommandTest extends TestCase
         $packageFactory = $this->createMock(ComposerPackageFactoryInterface::class);
         $packageFactory->method('loadPackage')->with($this->dir->url())->willReturn($this->package);
 
-        $this->input   = $this->prophesize(InputInterface::class);
-        $this->output  = $this->prophesize(ConsoleOutputInterface::class);
-        $this->command = new DeregisterCommand(
+        $this->input                             = $this->prophesize(InputInterface::class);
+        $this->output                            = $this->prophesize(ConsoleOutputInterface::class);
+        $this->command                           = new DeregisterCommand(
             $this->dir->url(),
             $packageFactory,
             $this->processFactory
@@ -108,9 +108,9 @@ class DeregisterCommandTest extends TestCase
         bool $removed,
         bool $disabled
     ): void {
-        $module                = 'MyApp';
-        $composer              = 'composer.phar';
-        $configProvider        = $module . '\ConfigProvider';
+        $module         = 'MyApp';
+        $composer       = 'composer.phar';
+        $configProvider = $module . '\ConfigProvider';
 
         $this->input->getArgument('module')->willReturn('MyApp');
         $this->input->getOption('composer')->willReturn('composer.phar');
@@ -180,7 +180,6 @@ class DeregisterCommandTest extends TestCase
                 ))
                 ->shouldBeCalled();
         }
-
 
         $method = $this->reflectExecuteMethod();
 

--- a/test/Module/DeregisterCommandTest.php
+++ b/test/Module/DeregisterCommandTest.php
@@ -5,18 +5,23 @@ declare(strict_types=1);
 namespace MezzioTest\Tooling\Module;
 
 use Laminas\ComponentInstaller\Injector\ConfigAggregatorInjector;
-use Laminas\ComposerAutoloading\Command\Disable;
-use Laminas\ComposerAutoloading\Exception\RuntimeException;
+use Mezzio\Tooling\Composer\ComposerPackageFactoryInterface;
+use Mezzio\Tooling\Composer\ComposerPackageInterface;
+use Mezzio\Tooling\Composer\ComposerProcessFactoryInterface;
+use Mezzio\Tooling\Composer\ComposerProcessInterface;
+use Mezzio\Tooling\Composer\ComposerProcessResultInterface;
 use Mezzio\Tooling\Module\DeregisterCommand;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
+use RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 
@@ -41,14 +46,30 @@ class DeregisterCommandTest extends TestCase
     /** @var string */
     private $expectedModuleArgumentDescription;
 
+    /** @var ComposerPackageInterface&MockObject */
+    private $package;
+
+    /** @var ComposerProcessFactoryInterface&MockObject */
+    private $processFactory;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->dir                               = vfsStream::setup('project');
-        $this->input                             = $this->prophesize(InputInterface::class);
-        $this->output                            = $this->prophesize(ConsoleOutputInterface::class);
-        $this->command                           = new DeregisterCommand('');
+        $this->dir            = vfsStream::setup('project');
+        $this->package        = $this->createMock(ComposerPackageInterface::class);
+        $this->processFactory = $this->createMock(ComposerProcessFactoryInterface::class);
+
+        $packageFactory = $this->createMock(ComposerPackageFactoryInterface::class);
+        $packageFactory->method('loadPackage')->with($this->dir->url())->willReturn($this->package);
+
+        $this->input   = $this->prophesize(InputInterface::class);
+        $this->output  = $this->prophesize(ConsoleOutputInterface::class);
+        $this->command = new DeregisterCommand(
+            $this->dir->url(),
+            $packageFactory,
+            $this->processFactory
+        );
         $this->expectedModuleArgumentDescription = DeregisterCommand::HELP_ARG_MODULE;
     }
 
@@ -69,57 +90,97 @@ class DeregisterCommandTest extends TestCase
         self::assertEquals(DeregisterCommand::HELP, $this->command->getHelp());
     }
 
-    /** @psalm-return array<array-key, array{0: bool, 1: bool}> */
+    /** @psalm-return array<string, array{0: bool, 1: bool}> */
     public function removedDisabled(): array
     {
         return [
-            // $removed, $disabled
-            [true,       true],
-            [true,       false],
-            [false,      true],
-            [false,      false],
+            'removed and disabled'         => [true,  true],
+            'removed and NOT disabled'     => [true,  false],
+            'NOT removed but disabled'     => [false, true],
+            'NOT removed and NOT disabled' => [false, false],
         ];
     }
 
     /**
      * @dataProvider removedDisabled
-     * @param bool $removed
-     * @param bool $disabled
      */
-    public function testRemoveFromConfigurationAndDisableModuleEmitsExpectedMessages($removed, $disabled)
-    {
+    public function testRemoveFromConfigurationAndDisableModuleEmitsExpectedMessages(
+        bool $removed,
+        bool $disabled
+    ): void {
+        $module                = 'MyApp';
+        $composer              = 'composer.phar';
+        $configProvider        = $module . '\ConfigProvider';
+
+        $this->input->getArgument('module')->willReturn('MyApp');
+        $this->input->getOption('composer')->willReturn('composer.phar');
+
         $injectorMock = Mockery::mock('overload:' . ConfigAggregatorInjector::class);
         $injectorMock
             ->shouldReceive('isRegistered')
-            ->with('MyApp\ConfigProvider')
+            ->with($configProvider)
             ->andReturn($removed)
             ->once();
         if ($removed) {
             $injectorMock
                 ->shouldReceive('remove')
-                ->with('MyApp\ConfigProvider')
+                ->with($configProvider)
                 ->once();
         } else {
             $injectorMock
                 ->shouldNotReceive('remove');
         }
 
-        $disableMock = Mockery::mock('overload:' . Disable::class);
-        $disableMock
-            ->shouldReceive('process')
-            ->with('MyApp')
-            ->andReturn($disabled)
-            ->once();
+        $this->package
+            ->expects($this->once())
+            ->method('removePsr4AutoloadRule')
+            ->with($module, false)
+            ->willReturn($disabled);
 
-        $this->input->getArgument('module')->willReturn('MyApp');
-        $this->input->getOption('composer')->willReturn('composer.phar');
-        $this->input->getOption('modules-path')->willReturn('./library/modules');
+        if ($disabled === true) {
+            $processResult = new class implements ComposerProcessResultInterface {
+                public function isSuccessful(): bool
+                {
+                    return true;
+                }
 
-        $this->output
-            ->writeln(Argument::containingString(
-                'Removed autoloading rules and configuration entries for module MyApp'
-            ))
-            ->shouldBeCalled();
+                public function getOutput(): string
+                {
+                    return '';
+                }
+
+                public function getErrorOutput(): string
+                {
+                    throw new RuntimeException(__METHOD__ . ' should not be called');
+                }
+            };
+
+            $process = $this->createMock(ComposerProcessInterface::class);
+            $process->expects($this->once())->method('run')->willReturn($processResult);
+            $this->processFactory
+                ->expects($this->once())
+                ->method('createProcess')
+                ->with([$composer, 'dump-autoload'])
+                ->willReturn($process);
+
+            $this->output
+                ->writeln(Argument::containingString(
+                    'Removed config provider and autoloading rules for module ' . $module
+                ))
+                ->shouldBeCalled();
+        }
+
+        if ($disabled === false) {
+            $this->processFactory
+                ->expects($this->never())
+                ->method('createProcess');
+            $this->output
+                ->writeln(Argument::containingString(
+                    'Removed config provider for module ' . $module
+                ))
+                ->shouldBeCalled();
+        }
+
 
         $method = $this->reflectExecuteMethod();
 
@@ -132,6 +193,10 @@ class DeregisterCommandTest extends TestCase
 
     public function testAllowsExceptionsThrownFromDisableToBubbleUp()
     {
+        $this->input->getArgument('module')->willReturn('MyApp');
+        $this->input->getOption('composer')->willReturn('composer.phar');
+        $this->input->getOption('modules-path')->willReturn('./library/modules');
+
         $injectorMock = Mockery::mock('overload:' . ConfigAggregatorInjector::class);
         $injectorMock
             ->shouldReceive('isRegistered')
@@ -139,16 +204,13 @@ class DeregisterCommandTest extends TestCase
             ->andReturn(false)
             ->once();
 
-        $disableMock = Mockery::mock('overload:' . Disable::class);
-        $disableMock
-            ->shouldReceive('process')
-            ->with('MyApp')
-            ->andThrow(RuntimeException::class, 'Testing Exception Message')
-            ->once();
+        $this->package
+            ->expects($this->once())
+            ->method('removePsr4AutoloadRule')
+            ->with('MyApp', false)
+            ->willThrowException(new RuntimeException('Testing Exception Message'));
 
-        $this->input->getArgument('module')->willReturn('MyApp');
-        $this->input->getOption('composer')->willReturn('composer.phar');
-        $this->input->getOption('modules-path')->willReturn('./library/modules');
+        $this->processFactory->expects($this->never())->method('createProcess');
 
         $method = $this->reflectExecuteMethod();
 

--- a/test/Module/RegisterCommandTest.php
+++ b/test/Module/RegisterCommandTest.php
@@ -6,13 +6,18 @@ namespace MezzioTest\Tooling\Module;
 
 use Laminas\ComponentInstaller\Injector\ConfigAggregatorInjector;
 use Laminas\ComponentInstaller\Injector\InjectorInterface;
-use Laminas\ComposerAutoloading\Command\Enable;
-use Laminas\ComposerAutoloading\Exception\RuntimeException;
+use Mezzio\Tooling\Composer\ComposerPackageFactoryInterface;
+use Mezzio\Tooling\Composer\ComposerPackageInterface;
+use Mezzio\Tooling\Composer\ComposerProcessFactoryInterface;
+use Mezzio\Tooling\Composer\ComposerProcessInterface;
+use Mezzio\Tooling\Composer\ComposerProcessResultInterface;
 use Mezzio\Tooling\Module\RegisterCommand;
+use Mezzio\Tooling\Module\RuntimeException;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -42,14 +47,30 @@ class RegisterCommandTest extends TestCase
     /** @var string */
     private $expectedModuleArgumentDescription;
 
+    /** @var ComposerPackageInterface&MockObject */
+    private $package;
+
+    /** @var ComposerProcessFactoryInterface&MockObject */
+    private $processFactory;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->dir                               = vfsStream::setup('project');
-        $this->input                             = $this->prophesize(InputInterface::class);
-        $this->output                            = $this->prophesize(ConsoleOutputInterface::class);
-        $this->command                           = new RegisterCommand('');
+        $this->dir            = vfsStream::setup('project');
+        $this->package        = $this->createMock(ComposerPackageInterface::class);
+        $this->processFactory = $this->createMock(ComposerProcessFactoryInterface::class);
+
+        $packageFactory = $this->createMock(ComposerPackageFactoryInterface::class);
+        $packageFactory->method('loadPackage')->with($this->dir->url())->willReturn($this->package);
+
+        $this->input   = $this->prophesize(InputInterface::class);
+        $this->output  = $this->prophesize(ConsoleOutputInterface::class);
+        $this->command = new RegisterCommand(
+            $this->dir->url(),
+            $packageFactory,
+            $this->processFactory
+        );
         $this->expectedModuleArgumentDescription = RegisterCommand::HELP_ARG_MODULE;
     }
 
@@ -70,61 +91,127 @@ class RegisterCommandTest extends TestCase
         self::assertEquals(RegisterCommand::HELP, $this->command->getHelp());
     }
 
-    /** @psalm-return array<array-key, array{0: bool, 1: bool}> */
+    /** @psalm-return array<string, array{0: bool, 1: bool, 2: bool, 3: string}> */
     public function injectedEnabled(): array
     {
         return [
-            // $injected, $enabled
-            [true,        true],
-            [true,        false],
-            [false,       true],
-            [false,       false],
+            'custom module structure, injected and enabled'              => [true,  true,  true,  './library/modules'],
+            'custom module structure, injected and NOT enabled'          => [true,  false, true,  './library/modules'],
+            'custom module structure, NOT injected but enabled'          => [false, true,  true,  './library/modules'],
+            'custom module structure, NOT injected and NOT enabled'      => [false, false, true,  './library/modules'],
+            'recommended module structure, injected and enabled'         => [true,  true,  true,  'src'],
+            'recommended module structure, injected and NOT enabled'     => [true,  false, true,  'src'],
+            'recommended module structure, NOT injected but enabled'     => [false, true,  true,  'src'],
+            'recommended module structure, NOT injected and NOT enabled' => [false, false, true,  'src'],
+            'flat module structure, injected and enabled'                => [true,  true,  false, 'src'],
+            'flat module structure, injected and NOT enabled'            => [true,  false, false, 'src'],
+            'flat module structure, NOT injected but enabled'            => [false, true,  false, 'src'],
+            'flat module structure, NOT injected and NOT enabled'        => [false, false, false, 'src'],
         ];
     }
 
     /**
      * @dataProvider injectedEnabled
-     * @param bool $injected
-     * @param bool $enabled
      */
-    public function testCommandEmitsExpectedMessagesWhenItInjectsConfigurationAndEnablesModule($injected, $enabled)
-    {
+    public function testCommandEmitsExpectedMessagesWhenItInjectsConfigurationAndEnablesModule(
+        bool $injected,
+        bool $enabled,
+        bool $isRecommendedStructure,
+        string $modulesPath
+    ): void {
+        $module                = 'MyApp';
+        $composer              = 'composer.phar';
+        $configProvider        = $module . '\ConfigProvider';
+        $normalizedModulesPath = preg_replace('#^./#', '', $modulesPath);
+        $expectedAutoloadPath  = sprintf(
+            '%s/%s%s',
+            $normalizedModulesPath,
+            $module,
+            $isRecommendedStructure ? '/src' : ''
+        );
+        $pathToCreate          = sprintf(
+            '%s/%s/%s%s',
+            $this->dir->url(),
+            $normalizedModulesPath,
+            $module,
+            $isRecommendedStructure ? '/src' : ''
+        );
+        mkdir($pathToCreate, 0777, true);
+
+        $this->input->getArgument('module')->willReturn($module);
+        $this->input->getOption('composer')->willReturn($composer);
+        $this->input->getOption('modules-path')->willReturn($modulesPath);
+
         $injectorMock = Mockery::mock('overload:' . ConfigAggregatorInjector::class);
         $injectorMock
             ->shouldReceive('isRegistered')
-            ->with('MyApp\ConfigProvider')
+            ->with($configProvider)
             ->andReturn(! $injected)
             ->once();
         if ($injected) {
             $injectorMock
                 ->shouldReceive('inject')
-                ->with('MyApp\ConfigProvider', InjectorInterface::TYPE_CONFIG_PROVIDER)
+                ->with($configProvider, InjectorInterface::TYPE_CONFIG_PROVIDER)
                 ->once();
         } else {
             $injectorMock
                 ->shouldNotReceive('inject');
         }
 
-        $enableMock = Mockery::mock('overload:' . Enable::class);
-        $enableMock
-            ->shouldReceive('setMoveModuleClass')
-            ->with(false)
-            ->once();
-        $enableMock
-            ->shouldReceive('process')
-            ->with('MyApp')
-            ->andReturn($enabled)
-            ->once();
+        $this->package
+            ->expects($this->once())
+            ->method('addPsr4AutoloadRule')
+            ->with(
+                $module,
+                $expectedAutoloadPath,
+                false
+            )
+            ->willReturn($enabled);
 
-        $this->input->getArgument('module')->willReturn('MyApp');
-        $this->input->getOption('composer')->willReturn('composer.phar');
-        $this->input->getOption('modules-path')->willReturn('./library/modules');
+        if ($enabled === true) {
+            $processResult = new class implements ComposerProcessResultInterface {
+                public function isSuccessful(): bool
+                {
+                    return true;
+                }
 
-        $this->output
-            ->writeln(Argument::containingString(
-                'Registered autoloading rules and added configuration entry for module MyApp'
-            ))
-            ->shouldBeCalled();
+                public function getOutput(): string
+                {
+                    return '';
+                }
+
+                public function getErrorOutput(): string
+                {
+                    throw new RuntimeException(__METHOD__ . ' should not be called');
+                }
+            };
+
+            $process = $this->createMock(ComposerProcessInterface::class);
+            $process->expects($this->once())->method('run')->willReturn($processResult);
+            $this->processFactory
+                ->expects($this->once())
+                ->method('createProcess')
+                ->with([$composer, 'dump-autoload'])
+                ->willReturn($process);
+
+            $this->output
+                ->writeln(Argument::containingString(
+                    'Registered config provider and autoloading rules for module ' . $module
+                ))
+                ->shouldBeCalled();
+        }
+
+        if ($enabled === false) {
+            $this->processFactory
+                ->expects($this->never())
+                ->method('createProcess');
+
+            $this->output
+                ->writeln(Argument::containingString(
+                    'Registered config provider for module ' . $module
+                ))
+                ->shouldBeCalled();
+        }
 
         $method = $this->reflectExecuteMethod();
 
@@ -137,6 +224,10 @@ class RegisterCommandTest extends TestCase
 
     public function testAllowsRuntimeExceptionsThrownFromEnableToBubbleUp()
     {
+        $this->input->getArgument('module')->willReturn('MyApp');
+        $this->input->getOption('composer')->willReturn('composer.phar');
+        $this->input->getOption('modules-path')->willReturn('./library/modules');
+
         $injectorMock = Mockery::mock('overload:' . ConfigAggregatorInjector::class);
         $injectorMock
             ->shouldReceive('isRegistered')
@@ -144,25 +235,12 @@ class RegisterCommandTest extends TestCase
             ->andReturn(true)
             ->once();
 
-        $enableMock = Mockery::mock('overload:' . Enable::class);
-        $enableMock
-            ->shouldReceive('setMoveModuleClass')
-            ->with(false)
-            ->once();
-        $enableMock
-            ->shouldReceive('process')
-            ->with('MyApp')
-            ->andThrow(RuntimeException::class, 'Testing Exception Message')
-            ->once();
-
-        $this->input->getArgument('module')->willReturn('MyApp');
-        $this->input->getOption('composer')->willReturn('composer.phar');
-        $this->input->getOption('modules-path')->willReturn('./library/modules');
+        $this->processFactory->expects($this->never())->method('createProcess');
 
         $method = $this->reflectExecuteMethod();
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Testing Exception Message');
+        $this->expectExceptionMessage('Cannot register module; directory "library/modules/MyApp" does not exist');
 
         $method->invoke(
             $this->command,

--- a/test/Module/RegisterCommandTest.php
+++ b/test/Module/RegisterCommandTest.php
@@ -26,6 +26,10 @@ use ReflectionMethod;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 
+use function mkdir;
+use function preg_replace;
+use function sprintf;
+
 class RegisterCommandTest extends TestCase
 {
     use CommonOptionsAndAttributesTrait;
@@ -64,9 +68,9 @@ class RegisterCommandTest extends TestCase
         $packageFactory = $this->createMock(ComposerPackageFactoryInterface::class);
         $packageFactory->method('loadPackage')->with($this->dir->url())->willReturn($this->package);
 
-        $this->input   = $this->prophesize(InputInterface::class);
-        $this->output  = $this->prophesize(ConsoleOutputInterface::class);
-        $this->command = new RegisterCommand(
+        $this->input                             = $this->prophesize(InputInterface::class);
+        $this->output                            = $this->prophesize(ConsoleOutputInterface::class);
+        $this->command                           = new RegisterCommand(
             $this->dir->url(),
             $packageFactory,
             $this->processFactory


### PR DESCRIPTION
This patch implements the ability to create a module with a "flat" structure.

While the recommended structure for modules is still the default, the Mezzio skeleton app also allows creating "flat" modules that contain **only** source code (no templates, tests, assets, or other items); this is particularly of interest when creating application-specific, API-facing modules where tests may exist at the application level, and no templates are needed.
As such, this patch now adds a "--flat" option to `mezzio:module:create` which will allow generating this simpler flat structure.

In order to allow this, I needed to migrate away from consuming laminas-composer-autoloading for enabling/disabling autoloader rules for modules.
The reason is because laminas-composer-autoloading assumes a laminas-mvc structured module, which coincides with our recommended structure.
Since the flat structure is not part of the MVC ecosystem, it becomes specific to this Mezzio tooling, and thus requires "in-lining" the functionality.
In reality, it is a completely new approach to handling the tasks, and was written from the ground-up with testing in mind.

As such, this patch:

- Removes the dependency on laminas-composer-autoloading.
- Adds a new dependency on symfony/process.
- Updates the `mezzio:module:register` and `mezzio:module:deregister` commands to use the new functionality.

Fixes #12
