### PR TITLE
Allow nested namespaces when creating modules

### DIFF
--- a/src/Module/Create.php
+++ b/src/Module/Create.php
@@ -8,8 +8,12 @@ use Mezzio\Tooling\TemplateResolutionTrait;
 
 use function file_exists;
 use function file_put_contents;
+use function ltrim;
 use function rtrim;
 use function sprintf;
+use function strlen;
+use function strpos;
+use function substr;
 
 final class Create
 {
@@ -187,8 +191,8 @@ final class Create
 
         return new ModuleMetadata(
             $moduleName,
-            $moduleRootPath,
-            $moduleSourcePath
+            $this->stripProjectRootFromPath($projectDir, $moduleRootPath),
+            $this->stripProjectRootFromPath($projectDir, $moduleSourcePath)
         );
     }
 
@@ -286,5 +290,15 @@ final class Create
         $filename = sprintf('%s/RoutesDelegator.php', $sourcePath);
 
         file_put_contents($filename, $classFileContents);
+    }
+
+    private function stripProjectRootFromPath(string $projectRoot, string $path): string
+    {
+        if (0 !== strpos($path, $projectRoot)) {
+            return $path;
+        }
+
+        $relativePath = substr($path, strlen($projectRoot));
+        return ltrim($relativePath, '/\\');
     }
 }

--- a/src/Module/ModuleMetadata.php
+++ b/src/Module/ModuleMetadata.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Mezzio\Tooling\Module;
 
+use function preg_replace;
+
 final class ModuleMetadata
 {
     /** @var string */
@@ -22,7 +24,7 @@ final class ModuleMetadata
     ) {
         $this->name       = $name;
         $this->rootPath   = $rootPath;
-        $this->sourcePath = $sourcePath;
+        $this->sourcePath = preg_replace('#^\./#', '', $sourcePath);
     }
 
     public function name(): string

--- a/test/Module/CreateCommandTest.php
+++ b/test/Module/CreateCommandTest.php
@@ -105,13 +105,13 @@ class CreateCommandTest extends TestCase
         string $name,
         string $module,
         string $composer,
-        string $modulesPath,
+        string $modulePath,
         $output
     ) {
         $register = $this->prophesize(Command::class);
         $register
             ->run(
-                Argument::that(function ($input) use ($name, $module, $composer, $modulesPath) {
+                Argument::that(function ($input) use ($name, $module, $composer, $modulePath) {
                     TestCase::assertInstanceOf(ArrayInput::class, $input);
 
                     $r = new ReflectionProperty($input, 'parameters');
@@ -127,8 +127,8 @@ class CreateCommandTest extends TestCase
                     TestCase::assertArrayHasKey('--composer', $parameters);
                     TestCase::assertEquals($composer, $parameters['--composer']);
 
-                    TestCase::assertArrayHasKey('--modules-path', $parameters);
-                    TestCase::assertEquals($modulesPath, $parameters['--modules-path']);
+                    TestCase::assertArrayHasKey('--exact-path', $parameters);
+                    TestCase::assertEquals($modulePath, $parameters['--exact-path']);
 
                     return true;
                 }),
@@ -169,7 +169,7 @@ class CreateCommandTest extends TestCase
         $creation    = Mockery::mock('overload:' . Create::class);
         $creation->shouldReceive('process')
             ->once()
-            ->with('Foo', 'library/modules', $projectRoot, false)
+            ->with('Foo', 'library/modules', $projectRoot, false, '')
             ->andReturn($metadata);
 
         $this->input->getArgument('module')->willReturn('Foo');
@@ -177,6 +177,7 @@ class CreateCommandTest extends TestCase
         $this->input->getOption('modules-path')->willReturn('./library/modules');
         $this->input->getOption('flat')->willReturn(false);
         $this->input->getOption('with-route-delegator')->willReturn(false);
+        $this->input->getOption('with-namespace')->willReturn('');
 
         vfsStream::copyFromFileSystem(__DIR__ . '/TestAsset', $this->dir);
         $command = new CreateCommand($this->createConfig($configAsArrayObject), $projectRoot);
@@ -190,7 +191,7 @@ class CreateCommandTest extends TestCase
             'mezzio:module:register',
             'Foo',
             'composer.phar',
-            'library/modules',
+            'library/modules/Foo/src',
             $this->output->reveal()
         );
         $command->setApplication($app->reveal());
@@ -217,7 +218,7 @@ class CreateCommandTest extends TestCase
         $creation    = Mockery::mock('overload:' . Create::class);
         $creation->shouldReceive('process')
             ->once()
-            ->with('Foo', 'library/modules', $projectRoot, false)
+            ->with('Foo', 'library/modules', $projectRoot, false, '')
             ->andReturn($metadata);
 
         $this->input->getArgument('module')->willReturn('Foo');
@@ -225,6 +226,7 @@ class CreateCommandTest extends TestCase
         $this->input->getOption('modules-path')->willReturn('./library/modules');
         $this->input->getOption('flat')->willReturn(false);
         $this->input->getOption('with-route-delegator')->willReturn(false);
+        $this->input->getOption('with-namespace')->willReturn('');
 
         vfsStream::copyFromFileSystem(__DIR__ . '/TestAsset', $this->dir);
 
@@ -239,7 +241,7 @@ class CreateCommandTest extends TestCase
             'mezzio:module:register',
             'Foo',
             'composer.phar',
-            'library/modules',
+            'library/modules/Foo/src',
             $this->output->reveal()
         );
         $command->setApplication($app->reveal());
@@ -260,7 +262,7 @@ class CreateCommandTest extends TestCase
         $projectRoot = getcwd();
         $creation    = Mockery::mock('overload:' . Create::class);
         $creation->shouldReceive('process')
-            ->with('Foo', 'library/modules', $projectRoot, false)
+            ->with('Foo', 'library/modules', $projectRoot, false, '')
             ->once()
             ->andThrow(RuntimeException::class, 'ERROR THROWN');
 
@@ -269,6 +271,7 @@ class CreateCommandTest extends TestCase
         $this->input->getOption('modules-path')->willReturn('./library/modules');
         $this->input->getOption('flat')->willReturn(false);
         $this->input->getOption('with-route-delegator')->willReturn(false);
+        $this->input->getOption('with-namespace')->willReturn('');
 
         vfsStream::copyFromFileSystem(__DIR__ . '/TestAsset', $this->dir);
 
@@ -299,7 +302,7 @@ class CreateCommandTest extends TestCase
         $creation    = Mockery::mock('overload:' . Create::class);
         $creation->shouldReceive('process')
             ->once()
-            ->with('Foo', 'library/modules', $projectRoot, false)
+            ->with('Foo', 'library/modules', $projectRoot, false, '')
             ->andReturn($metadata);
 
         $this->input->getArgument('module')->willReturn('Foo');
@@ -307,6 +310,7 @@ class CreateCommandTest extends TestCase
         $this->input->getOption('modules-path')->willReturn('./library/modules');
         $this->input->getOption('flat')->willReturn(true);
         $this->input->getOption('with-route-delegator')->willReturn(false);
+        $this->input->getOption('with-namespace')->willReturn('');
 
         vfsStream::copyFromFileSystem(__DIR__ . '/TestAsset', $this->dir);
         $command = new CreateCommand($this->createConfig($configAsArrayObject), $projectRoot);
@@ -320,7 +324,7 @@ class CreateCommandTest extends TestCase
             'mezzio:module:register',
             'Foo',
             'composer.phar',
-            'library/modules',
+            'library/modules/Foo',
             $this->output->reveal()
         );
         $command->setApplication($app->reveal());
@@ -347,7 +351,7 @@ class CreateCommandTest extends TestCase
         $creation    = Mockery::mock('overload:' . Create::class);
         $creation->shouldReceive('process')
             ->once()
-            ->with('Foo', 'library/modules', $projectRoot, true)
+            ->with('Foo', 'library/modules', $projectRoot, true, '')
             ->andReturn($metadata);
 
         $this->input->getArgument('module')->willReturn('Foo');
@@ -355,6 +359,7 @@ class CreateCommandTest extends TestCase
         $this->input->getOption('modules-path')->willReturn('./library/modules');
         $this->input->getOption('flat')->willReturn(false);
         $this->input->getOption('with-route-delegator')->willReturn(true);
+        $this->input->getOption('with-namespace')->willReturn('');
 
         vfsStream::copyFromFileSystem(__DIR__ . '/TestAsset', $this->dir);
         $command = new CreateCommand($this->createConfig($configAsArrayObject), $projectRoot);
@@ -368,7 +373,58 @@ class CreateCommandTest extends TestCase
             'mezzio:module:register',
             'Foo',
             'composer.phar',
-            'library/modules',
+            'library/modules/Foo/src',
+            $this->output->reveal()
+        );
+        $command->setApplication($app->reveal());
+
+        $method = $this->reflectExecuteMethod($command);
+        self::assertSame(0, $method->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+    }
+
+    /**
+     * @dataProvider configType
+     */
+    public function testCommandPassesParentNamespaceOptionDuringCreation(bool $configAsArrayObject): void
+    {
+        $metadata    = new ModuleMetadata(
+            'ParentNamespace\\Foo',
+            './library/modules',
+            './library/modules/Foo/src'
+        );
+        $projectRoot = getcwd();
+        $creation    = Mockery::mock('overload:' . Create::class);
+        $creation->shouldReceive('process')
+            ->once()
+            ->with('Foo', 'library/modules', $projectRoot, true, 'ParentNamespace')
+            ->andReturn($metadata);
+
+        $this->input->getArgument('module')->willReturn('Foo');
+        $this->input->getOption('composer')->willReturn('composer.phar');
+        $this->input->getOption('modules-path')->willReturn('./library/modules');
+        $this->input->getOption('flat')->willReturn(false);
+        $this->input->getOption('with-route-delegator')->willReturn(true);
+        $this->input->getOption('with-namespace')->willReturn('ParentNamespace');
+
+        vfsStream::copyFromFileSystem(__DIR__ . '/TestAsset', $this->dir);
+        $command = new CreateCommand($this->createConfig($configAsArrayObject), $projectRoot);
+
+        $this->output
+            ->writeln(Argument::containingString(
+                'Created module "ParentNamespace\\Foo" in directory "library/modules/Foo"'
+            ))
+            ->shouldBeCalled();
+
+        $app = $this->mockApplicationWithRegisterCommand(
+            0,
+            'mezzio:module:register',
+            'ParentNamespace\\Foo', // Note: passing parent namespace as module argument!
+            'composer.phar',
+            'library/modules/Foo/src',
             $this->output->reveal()
         );
         $command->setApplication($app->reveal());

--- a/test/Module/CreateTest.php
+++ b/test/Module/CreateTest.php
@@ -111,7 +111,7 @@ class CreateTest extends TestCase
         $configProvider = vfsStream::url('project/my-modules/MyApp/src/ConfigProvider.php');
         $metadata       = $this->command->process('MyApp', $this->modulesPath, $this->projectDir);
 
-        self::assertEquals(sprintf('%s/MyApp', $this->modulesDir->url()), $metadata->rootPath());
+        self::assertEquals('my-modules/MyApp', $metadata->rootPath());
         self::assertFileExists($configProvider);
         $configProviderContent = file_get_contents($configProvider);
         self::assertSame(1, preg_match('/\bnamespace MyApp\b/', $configProviderContent));
@@ -146,7 +146,7 @@ class CreateTest extends TestCase
         $command  = new Create(true);
         $metadata = $command->process('MyApp', $this->modulesPath, $this->projectDir);
 
-        $expectedPaths = sprintf('%s/MyApp', $this->modulesDir->url());
+        $expectedPaths = 'my-modules/MyApp';
         self::assertEquals($expectedPaths, $metadata->rootPath());
         self::assertEquals($expectedPaths, $metadata->sourcePath());
 
@@ -161,7 +161,7 @@ class CreateTest extends TestCase
         $command  = new Create(false);
         $metadata = $command->process('MyApp', $this->modulesPath, $this->projectDir, true);
 
-        $expectedPath = sprintf('%s/MyApp', $this->modulesDir->url());
+        $expectedPath = 'my-modules/MyApp';
         self::assertEquals($expectedPath, $metadata->rootPath());
         self::assertEquals($expectedPath . '/src', $metadata->sourcePath());
 
@@ -189,7 +189,7 @@ class CreateTest extends TestCase
         $command  = new Create(true, true);
         $metadata = $command->process('MyApp', $this->modulesPath, $this->projectDir, true);
 
-        $expectedPath = sprintf('%s/MyApp', $this->modulesDir->url());
+        $expectedPath = 'my-modules/MyApp';
         self::assertEquals($expectedPath, $metadata->rootPath());
         self::assertEquals($expectedPath, $metadata->sourcePath());
 
@@ -222,7 +222,7 @@ class CreateTest extends TestCase
             'ParentNamespace'
         );
 
-        self::assertEquals(sprintf('%s/MyApp', $this->modulesDir->url()), $metadata->rootPath());
+        self::assertEquals('my-modules/MyApp', $metadata->rootPath());
         self::assertFileExists($configProvider);
         $configProviderContent = file_get_contents($configProvider);
         self::assertSame(1, preg_match('/\bnamespace ParentNamespace\\\\MyApp\b/', $configProviderContent));
@@ -242,7 +242,7 @@ class CreateTest extends TestCase
         $command  = new Create(true);
         $metadata = $command->process('MyApp', $this->modulesPath, $this->projectDir, false, 'ParentNamespace');
 
-        $expectedPaths = sprintf('%s/MyApp', $this->modulesDir->url());
+        $expectedPaths = 'my-modules/MyApp';
         self::assertEquals($expectedPaths, $metadata->rootPath());
         self::assertEquals($expectedPaths, $metadata->sourcePath());
 
@@ -257,7 +257,7 @@ class CreateTest extends TestCase
         $command  = new Create(false);
         $metadata = $command->process('MyApp', $this->modulesPath, $this->projectDir, true, 'ParentNamespace');
 
-        $expectedPath = sprintf('%s/MyApp', $this->modulesDir->url());
+        $expectedPath = 'my-modules/MyApp';
         self::assertEquals($expectedPath, $metadata->rootPath());
         self::assertEquals($expectedPath . '/src', $metadata->sourcePath());
 
@@ -285,7 +285,7 @@ class CreateTest extends TestCase
         $command  = new Create(true, true);
         $metadata = $command->process('MyApp', $this->modulesPath, $this->projectDir, true, 'ParentNamespace');
 
-        $expectedPath = sprintf('%s/MyApp', $this->modulesDir->url());
+        $expectedPath = 'my-modules/MyApp';
         self::assertEquals($expectedPath, $metadata->rootPath());
         self::assertEquals($expectedPath, $metadata->sourcePath());
 

--- a/test/Module/CreateTest.php
+++ b/test/Module/CreateTest.php
@@ -210,4 +210,100 @@ class CreateTest extends TestCase
         );
         self::assertSame($expectedContent, $routesDelegatorContent);
     }
+
+    public function testCanCreateRecommendedStructureModuleUsingParentNamespace(): void
+    {
+        $configProvider = vfsStream::url('project/my-modules/MyApp/src/ConfigProvider.php');
+        $metadata       = $this->command->process(
+            'MyApp',
+            $this->modulesPath,
+            $this->projectDir,
+            false,
+            'ParentNamespace'
+        );
+
+        self::assertEquals(sprintf('%s/MyApp', $this->modulesDir->url()), $metadata->rootPath());
+        self::assertFileExists($configProvider);
+        $configProviderContent = file_get_contents($configProvider);
+        self::assertSame(1, preg_match('/\bnamespace ParentNamespace\\\\MyApp\b/', $configProviderContent));
+        self::assertSame(1, preg_match('/\bclass ConfigProvider\b/', $configProviderContent));
+        $command         = $this->command;
+        $expectedContent = sprintf(
+            $command::TEMPLATE_CONFIG_PROVIDER_RECOMMENDED,
+            'ParentNamespace\\MyApp',
+            'my-app',
+            ''
+        );
+        self::assertSame($expectedContent, $configProviderContent);
+    }
+
+    public function testCanCreateFlatStructureModuleUsingParentNamespace(): void
+    {
+        $command  = new Create(true);
+        $metadata = $command->process('MyApp', $this->modulesPath, $this->projectDir, false, 'ParentNamespace');
+
+        $expectedPaths = sprintf('%s/MyApp', $this->modulesDir->url());
+        self::assertEquals($expectedPaths, $metadata->rootPath());
+        self::assertEquals($expectedPaths, $metadata->sourcePath());
+
+        $configProvider        = vfsStream::url('project/my-modules/MyApp/ConfigProvider.php');
+        $configProviderContent = file_get_contents($configProvider);
+        $expectedContent       = sprintf($command::TEMPLATE_CONFIG_PROVIDER_FLAT, 'ParentNamespace\\MyApp', '');
+        self::assertSame($expectedContent, $configProviderContent);
+    }
+
+    public function testWillCreateRouteDelegatorUsingParentNamespace(): void
+    {
+        $command  = new Create(false);
+        $metadata = $command->process('MyApp', $this->modulesPath, $this->projectDir, true, 'ParentNamespace');
+
+        $expectedPath = sprintf('%s/MyApp', $this->modulesDir->url());
+        self::assertEquals($expectedPath, $metadata->rootPath());
+        self::assertEquals($expectedPath . '/src', $metadata->sourcePath());
+
+        $configProvider        = vfsStream::url('project/my-modules/MyApp/src/ConfigProvider.php');
+        $configProviderContent = file_get_contents($configProvider);
+        $expectedContent       = sprintf(
+            $command::TEMPLATE_CONFIG_PROVIDER_RECOMMENDED,
+            'ParentNamespace\\MyApp',
+            'my-app',
+            Create::TEMPLATE_ROUTE_DELEGATOR_CONFIG
+        );
+        self::assertSame($expectedContent, $configProviderContent);
+
+        $routesDelegator        = vfsStream::url('project/my-modules/MyApp/src/RoutesDelegator.php');
+        $routesDelegatorContent = file_get_contents($routesDelegator);
+        $expectedContent        = sprintf(
+            $command::TEMPLATE_ROUTE_DELEGATOR,
+            'ParentNamespace\\MyApp'
+        );
+        self::assertSame($expectedContent, $routesDelegatorContent);
+    }
+
+    public function testWillCreateRouteDelegatorInFlatStructureUsingParentNamespace(): void
+    {
+        $command  = new Create(true, true);
+        $metadata = $command->process('MyApp', $this->modulesPath, $this->projectDir, true, 'ParentNamespace');
+
+        $expectedPath = sprintf('%s/MyApp', $this->modulesDir->url());
+        self::assertEquals($expectedPath, $metadata->rootPath());
+        self::assertEquals($expectedPath, $metadata->sourcePath());
+
+        $configProvider        = vfsStream::url('project/my-modules/MyApp/ConfigProvider.php');
+        $configProviderContent = file_get_contents($configProvider);
+        $expectedContent       = sprintf(
+            $command::TEMPLATE_CONFIG_PROVIDER_FLAT,
+            'ParentNamespace\\MyApp',
+            Create::TEMPLATE_ROUTE_DELEGATOR_CONFIG
+        );
+        self::assertSame($expectedContent, $configProviderContent);
+
+        $routesDelegator        = vfsStream::url('project/my-modules/MyApp/RoutesDelegator.php');
+        $routesDelegatorContent = file_get_contents($routesDelegator);
+        $expectedContent        = sprintf(
+            $command::TEMPLATE_ROUTE_DELEGATOR,
+            'ParentNamespace\\MyApp'
+        );
+        self::assertSame($expectedContent, $routesDelegatorContent);
+    }
 }


### PR DESCRIPTION
Per #1, this feature adds the ability to specify a top-level namespace under which the new module will live when calling `mezzio:module:create`. The namespace may be provided using the `--with-namespace`/`-s` option, and, if present, it will be prefixed to the `module` argument provided. The use case for this is something along the lines of:

```bash
$ ./vendor/bin/laminas mezzio:module:create --with-namespace "MyCompany\MyOrganizationalGroup" SomeNewModule
```

To make this change possible, the `mezzio:module:register` command was updated to add an `--exact-path`/`-x` option, which expects a string path. When provided, that exact path will be mapped when generating an autoloader rule.
