### PR TITLE
Upgrade dependencies, add support for PHP 8.2, drop support for PHP 7.4

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,2 +1,5 @@
 {
+    "ignore_php_platform_requirements": {
+        "8.2": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         }
     },
     "require": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-json": "*",
         "laminas/laminas-cli": "^1.2",
         "laminas/laminas-code": "^4.5",

--- a/composer.json
+++ b/composer.json
@@ -37,26 +37,26 @@
     "require": {
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-json": "*",
-        "laminas/laminas-cli": "^1.2",
-        "laminas/laminas-code": "^4.5",
-        "laminas/laminas-stdlib": "^3.1",
-        "laminas/laminas-stratigility": "^3.0",
-        "mezzio/mezzio": "^3.0",
-        "mezzio/mezzio-router": "^3.0",
-        "symfony/process": "^4.3 || ^5.1.2 || ^6.0"
+        "laminas/laminas-cli": "^1.7.0",
+        "laminas/laminas-code": "^4.7.1",
+        "laminas/laminas-stdlib": "^3.15.0",
+        "laminas/laminas-stratigility": "^3.9.0",
+        "mezzio/mezzio": "^3.13.0",
+        "mezzio/mezzio-router": "^3.9.0",
+        "symfony/process": "^6.0.11"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.4.0",
-        "laminas/laminas-diactoros": "^1.8.7 || ^2.2.3",
+        "laminas/laminas-diactoros": "^2.2.3",
         "mikey179/vfsstream": "^1.6.11",
         "mockery/mockery": "^1.5.1",
         "php-mock/php-mock-phpunit": "^2.6.1",
-        "phpdocumentor/reflection-docblock": "^4.0.1 || ^5.0",
+        "phpdocumentor/reflection-docblock": "^5.3.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpunit/phpunit": "^9.5.26",
         "psalm/plugin-mockery": "^0.11.0",
-        "psalm/plugin-phpunit": "^0.18.0",
-        "vimeo/psalm": "^4.29.0"
+        "psalm/plugin-phpunit": "^0.18.3",
+        "vimeo/psalm": "^4.30.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "mockery/mockery": "^1.5.1",
         "php-mock/php-mock-phpunit": "^2.6.1",
         "phpdocumentor/reflection-docblock": "^5.3.0",
-        "phpspec/prophecy-phpunit": "^2.0.1",
         "phpunit/phpunit": "^9.5.26",
         "psalm/plugin-mockery": "^0.11.0",
         "psalm/plugin-phpunit": "^0.18.3",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
             "composer/package-versions-deprecated": true
         },
         "platform": {
-            "php": "7.4.99"
+            "php": "8.0.99"
         }
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49d270a20d9552c8b4eceb8d7edae9de",
+    "content-hash": "f1bbce24a9c4d2e1c013c6eca87efb12",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -64,21 +64,21 @@
         },
         {
             "name": "laminas/laminas-cli",
-            "version": "1.5.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cli.git",
-                "reference": "fb1076fbd0cb472fff3ebf9e08a7a9dbd70634a7"
+                "reference": "8476ca735f788cddc456ad660a29d9c8349554b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cli/zipball/fb1076fbd0cb472fff3ebf9e08a7a9dbd70634a7",
-                "reference": "fb1076fbd0cb472fff3ebf9e08a7a9dbd70634a7",
+                "url": "https://api.github.com/repos/laminas/laminas-cli/zipball/8476ca735f788cddc456ad660a29d9c8349554b0",
+                "reference": "8476ca735f788cddc456ad660a29d9c8349554b0",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.0.0",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/console": "^5.3.7 || ^6.0",
                 "symfony/event-dispatcher": "^5.0 || ^6.0",
@@ -86,13 +86,13 @@
                 "webmozart/assert": "^1.10"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-mvc": "^3.1.1",
-                "laminas/laminas-servicemanager": "^3.15.1",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-mvc": "^3.3.5",
+                "laminas/laminas-servicemanager": "^3.19",
                 "mikey179/vfsstream": "2.0.x-dev",
-                "phpunit/phpunit": "^9.5.9",
+                "phpunit/phpunit": "^9.5.25",
                 "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.24.0"
+                "vimeo/psalm": "^4.29"
             },
             "bin": [
                 "bin/laminas"
@@ -128,7 +128,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-08-03T17:19:22+00:00"
+            "time": "2022-10-13T22:36:07+00:00"
         },
         {
             "name": "laminas/laminas-code",
@@ -198,20 +198,20 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.17.0",
+            "version": "2.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "5b32597aa46b83c8b85bb1cf9a6ed4fe7dd980c5"
+                "reference": "df8c7f9e11d854269f4aa7c06ffa38caa42e4405"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/5b32597aa46b83c8b85bb1cf9a6ed4fe7dd980c5",
-                "reference": "5b32597aa46b83c8b85bb1cf9a6ed4fe7dd980c5",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/df8c7f9e11d854269f4aa7c06ffa38caa42e4405",
+                "reference": "df8c7f9e11d854269f4aa7c06ffa38caa42e4405",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ~8.0.0 || ~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0"
             },
@@ -230,9 +230,9 @@
                 "http-interop/http-factory-tests": "^0.9.0",
                 "laminas/laminas-coding-standard": "^2.4.0",
                 "php-http/psr7-integration-tests": "^1.1.1",
-                "phpunit/phpunit": "^9.5.23",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.24.0"
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.18.0",
+                "vimeo/psalm": "^4.29.0"
             },
             "type": "library",
             "extra": {
@@ -291,7 +291,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-08-30T17:01:46+00:00"
+            "time": "2022-11-22T05:54:54+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -357,30 +357,30 @@
         },
         {
             "name": "laminas/laminas-httphandlerrunner",
-            "version": "2.2.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-httphandlerrunner.git",
-                "reference": "eb670c5c7167cd218c61a8b4f6ab9ce339200c16"
+                "reference": "d15af53895fd581b5a448a09fd9a4baebc4ae6e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/eb670c5c7167cd218c61a8b4f6ab9ce339200c16",
-                "reference": "eb670c5c7167cd218c61a8b4f6ab9ce339200c16",
+                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/d15af53895fd581b5a448a09fd9a4baebc4ae6e5",
+                "reference": "d15af53895fd581b5a448a09fd9a4baebc4ae6e5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ~8.0.0 || ~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/http-message": "^1.0",
                 "psr/http-message-implementation": "^1.0",
                 "psr/http-server-handler": "^1.0"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.4.0",
-                "laminas/laminas-diactoros": "^2.13.0",
-                "phpunit/phpunit": "^9.5.21",
+                "laminas/laminas-diactoros": "^2.18",
+                "phpunit/phpunit": "^9.5.25",
                 "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.24.0"
+                "vimeo/psalm": "^4.28"
             },
             "type": "library",
             "extra": {
@@ -420,35 +420,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-09-17T16:24:51+00:00"
+            "time": "2022-10-25T13:41:39+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.13.0",
+            "version": "3.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "66a6d03c381f6c9f1dd988bf8244f9afb9380d76"
+                "reference": "63b66bd4b696f024f42616b9d95cdb10e5109c27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/66a6d03c381f6c9f1dd988bf8244f9afb9380d76",
-                "reference": "66a6d03c381f6c9f1dd988bf8244f9afb9380d76",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/63b66bd4b696f024f42616b9d95cdb10e5109c27",
+                "reference": "63b66bd4b696f024f42616b9d95cdb10e5109c27",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ~8.0.0 || ~8.1.0"
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-coding-standard": "^2.4.0",
                 "phpbench/phpbench": "^1.2.6",
-                "phpstan/phpdoc-parser": "^0.5.4",
-                "phpunit/phpunit": "^9.5.23",
+                "phpunit/phpunit": "^9.5.25",
                 "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.26"
+                "vimeo/psalm": "^4.28"
             },
             "type": "library",
             "autoload": {
@@ -480,26 +479,26 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-08-24T13:56:50+00:00"
+            "time": "2022-10-10T19:10:24+00:00"
         },
         {
             "name": "laminas/laminas-stratigility",
-            "version": "3.8.0",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stratigility.git",
-                "reference": "aa47a70ed02cff6109bf09aa7c3e85c574033d81"
+                "reference": "b847ad3a0a9f1c09de9bcc918454cc8d36efb6aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stratigility/zipball/aa47a70ed02cff6109bf09aa7c3e85c574033d81",
-                "reference": "aa47a70ed02cff6109bf09aa7c3e85c574033d81",
+                "url": "https://api.github.com/repos/laminas/laminas-stratigility/zipball/b847ad3a0a9f1c09de9bcc918454cc8d36efb6aa",
+                "reference": "b847ad3a0a9f1c09de9bcc918454cc8d36efb6aa",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1",
                 "laminas/laminas-escaper": "^2.10.0",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/http-message": "^1.0",
                 "psr/http-server-middleware": "^1.0"
             },
@@ -508,11 +507,11 @@
                 "zendframework/zend-stratigility": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-diactoros": "^2.13.0",
-                "phpunit/phpunit": "^9.5.21",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-diactoros": "^2.18",
+                "phpunit/phpunit": "^9.5.25",
                 "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.24.0"
+                "vimeo/psalm": "^4.28"
             },
             "suggest": {
                 "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., laminas/laminas-diactoros"
@@ -560,20 +559,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-07-23T13:56:06+00:00"
+            "time": "2022-10-10T19:34:46+00:00"
         },
         {
             "name": "mezzio/mezzio",
-            "version": "3.11.0",
+            "version": "3.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio.git",
-                "reference": "d5bf81f0caee6cf4b682a4bf1f8d693288bf217d"
+                "reference": "a9d6f7d6e45c37180059e5a4731a225ceb80cef1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio/zipball/d5bf81f0caee6cf4b682a4bf1f8d693288bf217d",
-                "reference": "d5bf81f0caee6cf4b682a4bf1f8d693288bf217d",
+                "url": "https://api.github.com/repos/mezzio/mezzio/zipball/a9d6f7d6e45c37180059e5a4731a225ceb80cef1",
+                "reference": "a9d6f7d6e45c37180059e5a4731a225ceb80cef1",
                 "shasum": ""
             },
             "require": {
@@ -582,7 +581,7 @@
                 "laminas/laminas-stratigility": "^3.5",
                 "mezzio/mezzio-router": "^3.7",
                 "mezzio/mezzio-template": "^2.2",
-                "php": "~7.4.0||~8.0.0||~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/container": "^1.0||^2.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0.1",
@@ -599,18 +598,17 @@
                 "zendframework/zend-expressive": "*"
             },
             "require-dev": {
-                "filp/whoops": "^2.14.4",
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-diactoros": "^2.11.2",
-                "laminas/laminas-servicemanager": "^3.10",
-                "malukenho/docheader": "^0.1.8",
-                "mezzio/mezzio-aurarouter": "^3.3.0",
-                "mezzio/mezzio-fastroute": "^3.3.0",
-                "mezzio/mezzio-laminasrouter": "^3.1.0",
-                "mockery/mockery": "^1.4.4",
-                "phpunit/phpunit": "^9.5.10",
-                "psalm/plugin-phpunit": "^0.13",
-                "vimeo/psalm": "^4.13.1"
+                "filp/whoops": "^2.14.5",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-diactoros": "^2.19",
+                "laminas/laminas-servicemanager": "^3.15",
+                "mezzio/mezzio-aurarouter": "^3.5",
+                "mezzio/mezzio-fastroute": "^3.7",
+                "mezzio/mezzio-laminasrouter": "^3.7",
+                "mockery/mockery": "^1.5.1",
+                "phpunit/phpunit": "^9.5.25",
+                "psalm/plugin-phpunit": "^0.17",
+                "vimeo/psalm": "^4.28"
             },
             "suggest": {
                 "filp/whoops": "^2.1 to use the Whoops error handler",
@@ -669,25 +667,25 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-06-29T21:47:57+00:00"
+            "time": "2022-10-11T08:04:06+00:00"
         },
         {
             "name": "mezzio/mezzio-router",
-            "version": "3.8.0",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-router.git",
-                "reference": "27075d3e9b407791abf7ba5e62954a59be4b18df"
+                "reference": "5b03ab8ef9ae8323a9093d5b9d79a69a3733968f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/27075d3e9b407791abf7ba5e62954a59be4b18df",
-                "reference": "27075d3e9b407791abf7ba5e62954a59be4b18df",
+                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/5b03ab8ef9ae8323a9093d5b9d79a69a3733968f",
+                "reference": "5b03ab8ef9ae8323a9093d5b9d79a69a3733968f",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/container": "^1.0 || ^2.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0.1",
@@ -699,14 +697,12 @@
                 "zendframework/zend-expressive-router": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-diactoros": "^2.6",
-                "laminas/laminas-stratigility": "^3.4",
-                "phpspec/prophecy": "^1.9",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.11",
-                "psalm/plugin-phpunit": "^0.15.0",
-                "vimeo/psalm": "^4.17"
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-diactoros": "^2.18",
+                "laminas/laminas-stratigility": "^3.8",
+                "phpunit/phpunit": "^9.5.25",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.28"
             },
             "suggest": {
                 "mezzio/mezzio-aurarouter": "^3.0 to use the Aura.Router routing adapter",
@@ -752,33 +748,33 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-01-06T16:27:49+00:00"
+            "time": "2022-10-10T19:40:00+00:00"
         },
         {
             "name": "mezzio/mezzio-template",
-            "version": "2.5.0",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-template.git",
-                "reference": "55b5ab7988ff495a9cdb5cbfc3e81dfb49cd06a6"
+                "reference": "ac7c34aa8b11efdd1a039af16f00bb625eab45bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-template/zipball/55b5ab7988ff495a9cdb5cbfc3e81dfb49cd06a6",
-                "reference": "55b5ab7988ff495a9cdb5cbfc3e81dfb49cd06a6",
+                "url": "https://api.github.com/repos/mezzio/mezzio-template/zipball/ac7c34aa8b11efdd1a039af16f00bb625eab45bd",
+                "reference": "ac7c34aa8b11efdd1a039af16f00bb625eab45bd",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ~8.0.0 || ~8.1.0"
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-expressive-template": "*"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "^9.5.24",
+                "phpunit/phpunit": "^9.5.25",
                 "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.27.0"
+                "vimeo/psalm": "^4.28"
             },
             "suggest": {
                 "mezzio/mezzio-laminasviewrenderer": "^2.0 to use the laminas-view PhpRenderer template renderer",
@@ -816,7 +812,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-09-14T08:07:39+00:00"
+            "time": "2022-10-10T21:46:43+00:00"
         },
         {
             "name": "psr/container",
@@ -1145,46 +1141,42 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.15",
+            "version": "v6.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ea59bb0edfaf9f28d18d8791410ee0355f317669"
+                "reference": "b0b910724a0a0326b4481e4f8a30abb2dd442efb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ea59bb0edfaf9f28d18d8791410ee0355f317669",
-                "reference": "ea59bb0edfaf9f28d18d8791410ee0355f317669",
+                "url": "https://api.github.com/repos/symfony/console/zipball/b0b910724a0a0326b4481e4f8a30abb2dd442efb",
+                "reference": "b0b910724a0a0326b4481e4f8a30abb2dd442efb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.0.2",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.9",
-                "symfony/polyfill-php80": "^1.16",
                 "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/string": "^5.1|^6.0"
+                "symfony/string": "^5.4|^6.0"
             },
             "conflict": {
-                "psr/log": ">=3",
-                "symfony/dependency-injection": "<4.4",
-                "symfony/dotenv": "<5.1",
-                "symfony/event-dispatcher": "<4.4",
-                "symfony/lock": "<4.4",
-                "symfony/process": "<4.4"
+                "symfony/dependency-injection": "<5.4",
+                "symfony/dotenv": "<5.4",
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/lock": "<5.4",
+                "symfony/process": "<5.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0|2.0"
+                "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
-                "psr/log": "^1|^2",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
-                "symfony/lock": "^4.4|^5.0|^6.0",
-                "symfony/process": "^4.4|^5.0|^6.0",
-                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/lock": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/var-dumper": "^5.4|^6.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -1224,7 +1216,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.15"
+                "source": "https://github.com/symfony/console/tree/v6.0.15"
             },
             "funding": [
                 {
@@ -1240,111 +1232,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-26T21:41:52+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v2.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-10-26T21:42:20+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.9",
+            "version": "v6.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "8e6ce1cc0279e3ff3c8ff0f43813bc88d21ca1bc"
+                "reference": "5c85b58422865d42c6eb46f7693339056db098a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/8e6ce1cc0279e3ff3c8ff0f43813bc88d21ca1bc",
-                "reference": "8e6ce1cc0279e3ff3c8ff0f43813bc88d21ca1bc",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/5c85b58422865d42c6eb46f7693339056db098a8",
+                "reference": "5c85b58422865d42c6eb46f7693339056db098a8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/event-dispatcher-contracts": "^2|^3",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.0.2",
+                "symfony/event-dispatcher-contracts": "^2|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<4.4"
+                "symfony/dependency-injection": "<5.4"
             },
             "provide": {
                 "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "2.0"
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/http-foundation": "^4.4|^5.0|^6.0",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/stopwatch": "^4.4|^5.0|^6.0"
+                "symfony/stopwatch": "^5.4|^6.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -1376,7 +1299,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.9"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.0.9"
             },
             "funding": [
                 {
@@ -1392,24 +1315,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-05T16:45:39+00:00"
+            "time": "2022-05-05T16:45:52+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.5.2",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "f98b54df6ad059855739db6fcbc2d36995283fe1"
+                "reference": "7bc61cc2db649b4637d331240c5346dcc7708051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/f98b54df6ad059855739db6fcbc2d36995283fe1",
-                "reference": "f98b54df6ad059855739db6fcbc2d36995283fe1",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7bc61cc2db649b4637d331240c5346dcc7708051",
+                "reference": "7bc61cc2db649b4637d331240c5346dcc7708051",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
                 "psr/event-dispatcher": "^1"
             },
             "suggest": {
@@ -1418,7 +1341,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1455,7 +1378,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.5.2"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.0.2"
             },
             "funding": [
                 {
@@ -1471,7 +1394,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1804,85 +1727,6 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
             "name": "symfony/polyfill-php80",
             "version": "v1.27.0",
             "source": {
@@ -1967,21 +1811,20 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.11",
+            "version": "v6.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1"
+                "reference": "44270a08ccb664143dede554ff1c00aaa2247a43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/6e75fe6874cbc7e4773d049616ab450eff537bf1",
-                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1",
+                "url": "https://api.github.com/repos/symfony/process/zipball/44270a08ccb664143dede554ff1c00aaa2247a43",
+                "reference": "44270a08ccb664143dede554ff1c00aaa2247a43",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.0.2"
             },
             "type": "library",
             "autoload": {
@@ -2009,7 +1852,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.11"
+                "source": "https://github.com/symfony/process/tree/v6.0.11"
             },
             "funding": [
                 {
@@ -2025,33 +1868,40 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-27T16:58:25+00:00"
+            "time": "2022-06-27T17:10:44+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.2",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0"
+                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/191afdcb5804db960d26d8566b7e9a2843cab3a0",
-                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
+                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": ">=8.0.2",
+                "psr/container": "^2.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
             },
             "suggest": {
-                "psr/container": "",
                 "symfony/service-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-main": "3.0-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -2084,40 +1934,53 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v1.1.2"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.0.2"
             },
-            "time": "2019-05-28T07:50:59+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-30T19:17:58+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.15",
+            "version": "v6.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "571334ce9f687e3e6af72db4d3b2a9431e4fd9ed"
+                "reference": "51ac0fa0ccf132a00519b87c97e8f775fa14e771"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/571334ce9f687e3e6af72db4d3b2a9431e4fd9ed",
-                "reference": "571334ce9f687e3e6af72db4d3b2a9431e4fd9ed",
+                "url": "https://api.github.com/repos/symfony/string/zipball/51ac0fa0ccf132a00519b87c97e8f775fa14e771",
+                "reference": "51ac0fa0ccf132a00519b87c97e8f775fa14e771",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "~1.15"
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/translation-contracts": ">=3.0"
+                "symfony/translation-contracts": "<2.0"
             },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/http-client": "^4.4|^5.0|^6.0",
-                "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0|^6.0"
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/http-client": "^5.4|^6.0",
+                "symfony/translation-contracts": "^2.0|^3.0",
+                "symfony/var-exporter": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -2156,7 +2019,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.15"
+                "source": "https://github.com/symfony/string/tree/v6.0.15"
             },
             "funding": [
                 {
@@ -2172,7 +2035,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-05T15:16:54+00:00"
+            "time": "2022-10-10T09:34:08+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4597,30 +4460,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4641,9 +4504,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -6002,7 +5865,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4.99"
+        "php": "8.0.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1431a1ae64349f42d83d98f8d63f8fbd",
+    "content-hash": "0ae092a9e97fa54a97ddd01640dfcd27",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -3760,125 +3760,6 @@
                 "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.2"
             },
             "time": "2022-10-14T12:47:21+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "v1.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.2",
-                "phpdocumentor/reflection-docblock": "^5.2",
-                "sebastian/comparator": "^3.0 || ^4.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^6.0 || ^7.0",
-                "phpunit/phpunit": "^8.0 || ^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
-            },
-            "time": "2021-12-08T12:19:24+00:00"
-        },
-        {
-            "name": "phpspec/prophecy-phpunit",
-            "version": "v2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy-phpunit.git",
-                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/2d7a9df55f257d2cba9b1d0c0963a54960657177",
-                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ^8",
-                "phpspec/prophecy": "^1.3",
-                "phpunit/phpunit": "^9.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\PhpUnit\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christophe Coevoet",
-                    "email": "stof@notk.org"
-                }
-            ],
-            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
-            "homepage": "http://phpspec.net",
-            "keywords": [
-                "phpunit",
-                "prophecy"
-            ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
-                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.0.1"
-            },
-            "time": "2020-07-09T08:33:42+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6e24fb8da370f8cbcdcf4d25504c008",
+    "content-hash": "1431a1ae64349f42d83d98f8d63f8fbd",
     "packages": [
         {
             "name": "fig/http-message-util",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1bbce24a9c4d2e1c013c6eca87efb12",
+    "content-hash": "d6e24fb8da370f8cbcdcf4d25504c008",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -5860,7 +5860,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-json": "*"
     },
     "platform-dev": [],

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -24,4 +24,9 @@
 
     <!-- Include all rules from the Laminas Coding Standard -->
     <rule ref="LaminasCodingStandard"/>
+    <rule ref="Generic.Files.LineLength.TooLong">
+        <exclude-pattern>/src/Factory/FactoryClassGenerator.php</exclude-pattern>
+        <exclude-pattern>/test/MigrateMiddlewareToRequestHandler/MigrateMiddlewareToRequestHandlerCommandTest.php</exclude-pattern>
+        <exclude-pattern>/test/MigrateMiddlewareToRequestHandler/ProjectSetupTrait.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
   <file src="src/Composer/FileSystemBasedComposerPackage.php">
     <MixedArrayAssignment occurrences="1">
       <code>$package[$key]['psr-4']</code>
@@ -18,8 +18,10 @@
       <code>$path</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion occurrences="3">
       <code>$key</code>
+      <code>$namespace</code>
+      <code>[$this-&gt;projectRoot, DIRECTORY_SEPARATOR, $path]</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="2">
       <code>$composer['autoload']</code>
@@ -72,20 +74,25 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$handler</code>
     </ArgumentTypeCoercion>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="3">
       <code>$config</code>
-      <code>$config</code>
+      <code>$path</code>
+      <code>$paths</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment occurrences="3">
       <code>$config</code>
+      <code>$path</code>
+      <code>$paths</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>null|string</code>
+    <MixedInferredReturnType occurrences="1">
       <code>string</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="1">
       <code>$config['templates']['extension']</code>
     </MixedReturnStatement>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$config</code>
+    </PossiblyInvalidArgument>
     <PossiblyNullArgument occurrences="2">
       <code>$rendererType</code>
       <code>$type</code>
@@ -98,9 +105,6 @@
       <code>TwigRenderer</code>
       <code>TwigRenderer</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="1">
-      <code>array|ArrayAccess</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="src/CreateMiddleware/CreateMiddleware.php">
     <MixedArgument occurrences="3">
@@ -108,8 +112,10 @@
       <code>$namespace</code>
       <code>$path</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion occurrences="3">
+      <code>$namespace</code>
       <code>[$namespace, $class]</code>
+      <code>[$projectRoot, DIRECTORY_SEPARATOR, $path]</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="2">
       <code>$composer['autoload']</code>
@@ -242,18 +248,20 @@
     </PossiblyInvalidDocblockTag>
   </file>
   <file src="src/Module/CommandCommonOptions.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument occurrences="2">
       <code>$command::HELP_ARG_MODULE</code>
+      <code>$modulesPath</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
+    <MixedArrayAccess occurrences="1">
+      <code>$config[self::class]['--modules-path']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$configuredModulesPath</code>
+      <code>$modulesPath</code>
+    </MixedAssignment>
     <UndefinedConstant occurrences="1">
       <code>$command::HELP_ARG_MODULE</code>
     </UndefinedConstant>
-    <UndefinedDocblockClass occurrences="1">
-      <code>array|ArrayAccess</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="src/Module/CreateCommand.php">
     <MixedArgument occurrences="2">
@@ -265,15 +273,13 @@
       <code>$module</code>
       <code>$parentNamespace</code>
     </MixedAssignment>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$this-&gt;config</code>
+    </PossiblyInvalidArgument>
     <PossiblyNullReference occurrences="1">
       <code>find</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>$config</code>
-      <code>$projectRoot</code>
-    </PropertyNotSetInConstructor>
-    <UndefinedDocblockClass occurrences="2">
-      <code>array|ArrayAccess</code>
+    <UndefinedDocblockClass occurrences="1">
       <code>array|ArrayAccess</code>
     </UndefinedDocblockClass>
   </file>
@@ -322,9 +328,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="src/TemplateResolutionTrait.php">
-    <MixedArgument occurrences="1">
-      <code>$renderer</code>
-    </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$renderer</code>
     </MixedAssignment>
@@ -354,12 +357,24 @@
     <InvalidStringClass occurrences="1">
       <code>new $renderer()</code>
     </InvalidStringClass>
-    <MixedArgument occurrences="2">
-      <code>$arguments</code>
+    <MixedArgument occurrences="14">
       <code>$config</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
+      <code>TestHandler::class</code>
     </MixedArgument>
     <MixedArrayAssignment occurrences="1">
-      <code>sprintf('config.php.%s', $config)</code>
+      <code>$arguments[]</code>
     </MixedArrayAssignment>
     <MixedArrayOffset occurrences="1"/>
     <MixedAssignment occurrences="2">
@@ -377,17 +392,28 @@
     <PropertyTypeCoercion occurrences="1">
       <code>new $renderer()</code>
     </PropertyTypeCoercion>
-    <UndefinedClass occurrences="6">
+    <UndefinedClass occurrences="20">
       <code>LaminasViewRenderer</code>
       <code>LaminasViewRenderer</code>
       <code>PlatesRenderer</code>
       <code>PlatesRenderer</code>
+      <code>PlatesRenderer|TwigRenderer|LaminasViewRenderer|null</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
+      <code>TestHandler</code>
       <code>TwigRenderer</code>
       <code>TwigRenderer</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="1">
-      <code>PlatesRenderer|TwigRenderer|LaminasViewRenderer</code>
-    </UndefinedDocblockClass>
     <UnresolvableInclude occurrences="15">
       <code>include $configFile</code>
       <code>require $sourceFile</code>
@@ -442,18 +468,27 @@
       <code>new Create($generator-&gt;reveal())</code>
       <code>new Create(new FactoryClassGenerator())</code>
     </InternalMethod>
+    <InvalidFunctionCall occurrences="1">
+      <code>$factory($container-&gt;reveal())</code>
+    </InvalidFunctionCall>
     <InvalidStringClass occurrences="1">
       <code>new $factoryName()</code>
     </InvalidStringClass>
-    <MixedAssignment occurrences="2">
-      <code>$factory</code>
+    <MixedArgument occurrences="3">
+      <code>$className</code>
+      <code>$className</code>
+      <code>$className</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="4">
+      <code>$className</code>
+      <code>$className</code>
+      <code>$className</code>
       <code>$instance</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="1">
-      <code>$factory($container-&gt;reveal())</code>
-    </MixedFunctionCall>
-    <UndefinedClass occurrences="1">
-      <code>$factoryName</code>
+    <UndefinedClass occurrences="3">
+      <code>TestClass</code>
+      <code>TestClass</code>
+      <code>TestClass</code>
     </UndefinedClass>
     <UnresolvableInclude occurrences="4">
       <code>require $fileName</code>
@@ -511,13 +546,5 @@
       <code>CommandCommonOptions::getModulesPath($this-&gt;input-&gt;reveal(), $config)</code>
       <code>CommandCommonOptions::getModulesPath($this-&gt;input-&gt;reveal(), $config)</code>
     </InternalMethod>
-    <MixedArrayAssignment occurrences="2">
-      <code>$config[CommandCommonOptions::class]['--modules-path']</code>
-      <code>$config[CommandCommonOptions::class]['--modules-path']</code>
-    </MixedArrayAssignment>
-    <PossiblyUndefinedVariable occurrences="2">
-      <code>$config</code>
-      <code>$config</code>
-    </PossiblyUndefinedVariable>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -482,7 +482,7 @@
     </ArgumentTypeCoercion>
     <InternalClass occurrences="5">
       <code>new Create($generator)</code>
-      <code>new Create($generator-&gt;reveal())</code>
+      <code>new Create($generator)</code>
       <code>new Create(new FactoryClassGenerator())</code>
       <code>new FactoryClassGenerator()</code>
       <code>new FactoryClassGenerator()</code>
@@ -492,11 +492,11 @@
       <code>createForClass</code>
       <code>createForClass</code>
       <code>new Create($generator)</code>
-      <code>new Create($generator-&gt;reveal())</code>
+      <code>new Create($generator)</code>
       <code>new Create(new FactoryClassGenerator())</code>
     </InternalMethod>
     <InvalidFunctionCall occurrences="1">
-      <code>$factory($container-&gt;reveal())</code>
+      <code>$factory($container)</code>
     </InvalidFunctionCall>
     <InvalidStringClass occurrences="1">
       <code>new $factoryName()</code>
@@ -547,12 +547,7 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="test/MigrateMiddlewareToRequestHandler/ProjectSetupTrait.php">
-    <MixedArgument occurrences="6">
-      <code>$arg</code>
-      <code>$arg</code>
-      <code>$arg</code>
-      <code>$arg</code>
-      <code>$arg</code>
+    <MixedArgument occurrences="1">
       <code>$file</code>
     </MixedArgument>
     <MixedAssignment occurrences="1">
@@ -564,14 +559,19 @@
   </file>
   <file src="test/Module/CommandCommonOptionsTest.php">
     <InternalClass occurrences="3">
-      <code>CommandCommonOptions::getModulesPath($this-&gt;input-&gt;reveal())</code>
-      <code>CommandCommonOptions::getModulesPath($this-&gt;input-&gt;reveal(), $config)</code>
-      <code>CommandCommonOptions::getModulesPath($this-&gt;input-&gt;reveal(), $config)</code>
+      <code>CommandCommonOptions::getModulesPath($this-&gt;input)</code>
+      <code>CommandCommonOptions::getModulesPath($this-&gt;input, $config)</code>
+      <code>CommandCommonOptions::getModulesPath($this-&gt;input, $config)</code>
     </InternalClass>
     <InternalMethod occurrences="3">
-      <code>CommandCommonOptions::getModulesPath($this-&gt;input-&gt;reveal())</code>
-      <code>CommandCommonOptions::getModulesPath($this-&gt;input-&gt;reveal(), $config)</code>
-      <code>CommandCommonOptions::getModulesPath($this-&gt;input-&gt;reveal(), $config)</code>
+      <code>CommandCommonOptions::getModulesPath($this-&gt;input)</code>
+      <code>CommandCommonOptions::getModulesPath($this-&gt;input, $config)</code>
+      <code>CommandCommonOptions::getModulesPath($this-&gt;input, $config)</code>
+    </InternalMethod>
+  </file>
+  <file src="test/TestAsset/config/container.php">
+    <InternalMethod occurrences="1">
+      <code>getMock</code>
     </InternalMethod>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,11 +5,29 @@
       <code>$package[$key]['psr-4']</code>
     </MixedArrayAssignment>
     <MixedInferredReturnType occurrences="1">
-      <code>array</code>
+      <code>mixed[]</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="1">
       <code>json_decode($contents, true, 512, JSON_THROW_ON_ERROR)</code>
     </MixedReturnStatement>
+  </file>
+  <file src="src/ConfigInjector/AbstractInjector.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>int[]</code>
+    </LessSpecificImplementedReturnType>
+    <PropertyTypeCoercion occurrences="2">
+      <code>$modules</code>
+      <code>$modules</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="src/ConfigProvider.php">
+    <InvalidDocblock occurrences="1">
+      <code>public function getConsoleConfig(): array</code>
+    </InvalidDocblock>
+    <InvalidReturnStatement occurrences="1"/>
+    <InvalidReturnType occurrences="1">
+      <code>array{factories: array{Create: string, CreateActionCommand: string, CreateCommand: string, CreateFactoryCommand: string, CreateHandlerCommand: string, CreateMiddlewareCommand: string, DeregisterCommand: string, MigrateInteropMiddlewareCommand: string, MigrateMiddlewareToRequestHandlerCommand: string, RegisterCommand: string}}</code>
+    </InvalidReturnType>
   </file>
   <file src="src/CreateHandler/CreateHandler.php">
     <MixedArgument occurrences="4">
@@ -97,10 +115,8 @@
       <code>$rendererType</code>
       <code>$type</code>
     </PossiblyNullArgument>
-    <UndefinedClass occurrences="6">
+    <UndefinedClass occurrences="4">
       <code>LaminasViewRenderer</code>
-      <code>LaminasViewRenderer</code>
-      <code>PlatesRenderer</code>
       <code>PlatesRenderer</code>
       <code>TwigRenderer</code>
       <code>TwigRenderer</code>
@@ -303,15 +319,12 @@
     </MixedAssignment>
   </file>
   <file src="src/Module/RegisterCommand.php">
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$packageFactory-&gt;loadPackage($projectRoot)</code>
-    </InvalidPropertyAssignmentValue>
     <MixedArgument occurrences="5">
       <code>$composer</code>
       <code>$module</code>
       <code>$module</code>
       <code>$module</code>
-      <code>$module</code>
+      <code>$modulePath</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>[$composer, 'dump-autoload']</code>
@@ -322,10 +335,6 @@
       <code>$module</code>
       <code>$modulePath</code>
     </MixedAssignment>
-    <UndefinedDocblockClass occurrences="2">
-      <code>$this-&gt;package</code>
-      <code>ComposerPackageInterface</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="src/TemplateResolutionTrait.php">
     <MixedAssignment occurrences="1">
@@ -342,7 +351,7 @@
     <MixedInferredReturnType occurrences="3">
       <code>array</code>
       <code>array</code>
-      <code>array</code>
+      <code>mixed[]</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="1">
       <code>json_decode($json, true, 512, JSON_THROW_ON_ERROR)</code>
@@ -352,6 +361,24 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$type</code>
     </ArgumentTypeCoercion>
+  </file>
+  <file src="test/ConfigInjector/ConfigAggregatorInjectorTest.php">
+    <ImplementedReturnTypeMismatch occurrences="4">
+      <code>array&lt;string, array&lt;string|bool&gt;&gt;</code>
+      <code>array&lt;string, array&lt;string|bool&gt;&gt;</code>
+      <code>array&lt;string, array&lt;string|bool|int&gt;&gt;</code>
+      <code>array&lt;string, array&lt;string|bool|int&gt;&gt;</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidReturnStatement occurrences="4"/>
+    <InvalidReturnType occurrences="4">
+      <code>array&lt;string, array&lt;string|bool&gt;&gt;</code>
+      <code>array&lt;string, array&lt;string|bool&gt;&gt;</code>
+      <code>array&lt;string, array&lt;string|bool|int&gt;&gt;</code>
+      <code>array&lt;string, array&lt;string|bool|int&gt;&gt;</code>
+    </InvalidReturnType>
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array&lt;string, mixed[]&gt;</code>
+    </LessSpecificImplementedReturnType>
   </file>
   <file src="test/CreateHandler/CreateTemplateTest.php">
     <InvalidStringClass occurrences="1">

--- a/src/Composer/ComposerProcessResultViaSymfonyProcess.php
+++ b/src/Composer/ComposerProcessResultViaSymfonyProcess.php
@@ -8,11 +8,8 @@ use Symfony\Component\Process\Process;
 
 final class ComposerProcessResultViaSymfonyProcess implements ComposerProcessResultInterface
 {
-    private Process $process;
-
-    public function __construct(Process $process)
+    public function __construct(private Process $process)
     {
-        $this->process = $process;
     }
 
     public function isSuccessful(): bool

--- a/src/Composer/ComposerProcessViaSymfonyProcess.php
+++ b/src/Composer/ComposerProcessViaSymfonyProcess.php
@@ -9,11 +9,8 @@ use Symfony\Component\Process\Process;
 /** @internal */
 class ComposerProcessViaSymfonyProcess implements ComposerProcessInterface
 {
-    private Process $process;
-
-    public function __construct(Process $process)
+    public function __construct(private Process $process)
     {
-        $this->process = $process;
     }
 
     public function run(): ComposerProcessResultInterface

--- a/src/Composer/FileSystemBasedComposerPackage.php
+++ b/src/Composer/FileSystemBasedComposerPackage.php
@@ -65,6 +65,9 @@ final class FileSystemBasedComposerPackage implements ComposerPackageInterface
         return true;
     }
 
+    /**
+     * @return mixed[]
+     */
     private function parse(): array
     {
         if (! file_exists($this->composerFile)) {

--- a/src/ConfigDiscovery/AbstractDiscovery.php
+++ b/src/ConfigDiscovery/AbstractDiscovery.php
@@ -38,9 +38,11 @@ abstract class AbstractDiscovery implements DiscoveryInterface
         if ('' === $projectDirectory) {
             return;
         }
+
         if (! is_dir($projectDirectory)) {
             return;
         }
+
         $this->configFile = sprintf(
             '%s/%s',
             $projectDirectory,

--- a/src/ConfigDiscovery/AbstractDiscovery.php
+++ b/src/ConfigDiscovery/AbstractDiscovery.php
@@ -35,13 +35,17 @@ abstract class AbstractDiscovery implements DiscoveryInterface
      */
     public function __construct(string $projectDirectory = '')
     {
-        if ('' !== $projectDirectory && is_dir($projectDirectory)) {
-            $this->configFile = sprintf(
-                '%s/%s',
-                $projectDirectory,
-                $this->configFile
-            );
+        if ('' === $projectDirectory) {
+            return;
         }
+        if (! is_dir($projectDirectory)) {
+            return;
+        }
+        $this->configFile = sprintf(
+            '%s/%s',
+            $projectDirectory,
+            $this->configFile
+        );
     }
 
     /**

--- a/src/ConfigInjector/AbstractInjector.php
+++ b/src/ConfigInjector/AbstractInjector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mezzio\Tooling\ConfigInjector;
 
 use Mezzio\Tooling\Exception;
+use Mezzio\Tooling\Exception\RuntimeException;
 
 use function addslashes;
 use function assert;
@@ -211,7 +212,7 @@ abstract class AbstractInjector implements InjectorInterface
     {
         foreach ($this->moduleDependencies as $dependency) {
             if (! $this->isRegisteredInConfig($dependency, $config)) {
-                throw new Exception\RuntimeException(sprintf(
+                throw new RuntimeException(sprintf(
                     'Dependency %s is not registered in the configuration',
                     $dependency
                 ));

--- a/src/ConfigInjector/AbstractInjector.php
+++ b/src/ConfigInjector/AbstractInjector.php
@@ -154,6 +154,9 @@ abstract class AbstractInjector implements InjectorInterface
         return in_array($type, $this->allowedTypes, true);
     }
 
+    /**
+     * @return int[]
+     */
     public function getTypesAllowed(): array
     {
         return $this->allowedTypes;
@@ -320,6 +323,9 @@ abstract class AbstractInjector implements InjectorInterface
         return $first;
     }
 
+    /**
+     * @param string[] $modules
+     */
     public function setApplicationModules(array $modules): self
     {
         $this->applicationModules = $modules;
@@ -327,6 +333,9 @@ abstract class AbstractInjector implements InjectorInterface
         return $this;
     }
 
+    /**
+     * @param string[] $modules
+     */
     public function setModuleDependencies(array $modules): self
     {
         $this->moduleDependencies = $modules;

--- a/src/ConfigInjector/ConfigAggregatorInjector.php
+++ b/src/ConfigInjector/ConfigAggregatorInjector.php
@@ -18,6 +18,9 @@ final class ConfigAggregatorInjector extends AbstractInjector
 {
     use ConditionalDiscoveryTrait;
 
+    /**
+     * @var string
+     */
     public const DEFAULT_CONFIG_FILE = 'config/config.php';
 
     /** @var list<InjectorInterface::TYPE_*> */
@@ -75,7 +78,7 @@ final class ConfigAggregatorInjector extends AbstractInjector
         $this->isRegisteredPattern = '/new (?:'
             . $ns
             . '?'
-            . preg_quote('Laminas\ConfigAggregator\\')
+            . preg_quote('Laminas\ConfigAggregator\\', '/')
             . ')?ConfigAggregator\(\s*(?:array\(|\[).*\s+'
             . $ns
             . '?%s::class/s';

--- a/src/ConfigInjector/InjectorInterface.php
+++ b/src/ConfigInjector/InjectorInterface.php
@@ -13,10 +13,29 @@ use Mezzio\Tooling\Exception;
  */
 interface InjectorInterface
 {
-    public const TYPE_CONFIG_PROVIDER    = 0;
-    public const TYPE_COMPONENT          = 1;
-    public const TYPE_MODULE             = 2;
-    public const TYPE_DEPENDENCY         = 3;
+    /**
+     * @var int
+     */
+    public const TYPE_CONFIG_PROVIDER = 0;
+
+    /**
+     * @var int
+     */
+    public const TYPE_COMPONENT = 1;
+
+    /**
+     * @var int
+     */
+    public const TYPE_MODULE = 2;
+
+    /**
+     * @var int
+     */
+    public const TYPE_DEPENDENCY = 3;
+
+    /**
+     * @var int
+     */
     public const TYPE_BEFORE_APPLICATION = 4;
 
     /**

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -36,6 +36,9 @@ final class ConfigProvider
         ];
     }
 
+    /**
+     * @return array<string, array{mezzio:action:create: class-string<CreateActionCommand>, mezzio:factory:create: class-string<CreateFactoryCommand>, mezzio:handler:create: class-string<CreateHandlerCommand>, mezzio:middleware:create: class-string<CreateMiddlewareCommand>, mezzio:middleware:migrate-from-interop: class-string<MigrateInteropMiddlewareCommand>, mezzio:middleware:to-request-handler: class-string<MigrateMiddlewareToRequestHandlerCommand>, mezzio:module:create: class-string<CreateCommand>, mezzio:module:deregister: class-string<DeregisterCommand>, mezzio:module:register: class-string<RegisterCommand>}>
+     */
     public function getConsoleConfig(): array
     {
         return [
@@ -53,6 +56,9 @@ final class ConfigProvider
         ];
     }
 
+    /**
+     * @return array{factories: array{Create: string, CreateActionCommand: string, CreateCommand: string, CreateFactoryCommand: string, CreateHandlerCommand: string, CreateMiddlewareCommand: string, DeregisterCommand: string, MigrateInteropMiddlewareCommand: string, MigrateMiddlewareToRequestHandlerCommand: string, RegisterCommand: string}}
+     */
     public function getDependencies(): array
     {
         return [

--- a/src/CreateHandler/CreateActionCommand.php
+++ b/src/CreateHandler/CreateActionCommand.php
@@ -9,32 +9,50 @@ use Symfony\Component\Console\Input\InputOption;
 
 final class CreateActionCommand extends CreateHandlerCommand
 {
+    /**
+     * @var string
+     */
     public const HELP_DESCRIPTION = 'Create an action class file.';
 
+    /**
+     * @var string
+     */
     public const HELP = <<<'EOT'
         Creates an action class file named after the provided class. For a path, it
         matches the class namespace against PSR-4 autoloader namespaces in your
         composer.json.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_ARG_ACTION = <<<'EOT'
         Fully qualified class name of the action class to create. This value
         should be quoted to ensure namespace separators are not interpreted as
         escape sequences by your shell.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_OPT_NO_FACTORY = <<<'EOT'
         By default, this command generates a factory for the action class it creates,
         and registers it with the container. Passing this option disables that
         feature.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_OPT_NO_REGISTER = <<<'EOT'
         By default, when this command generates a factory for the action class it
         creates, it registers it with the container. Passing this option disables
         registration of the generated factory with the container.
         EOT;
 
+    /**
+     * @var string
+     */
     public const STATUS_TEMPLATE = '<info>Creating action %s...</info>';
 
     /** @var null|string Cannot be defined explicitly due to parent class */

--- a/src/CreateHandler/CreateHandlerCommand.php
+++ b/src/CreateHandler/CreateHandlerCommand.php
@@ -19,40 +19,64 @@ class CreateHandlerCommand extends Command
 {
     use TemplateResolutionTrait;
 
+    /**
+     * @var string
+     */
     public const DEFAULT_SRC = '/src';
 
+    /**
+     * @var string
+     */
     public const HELP_DESCRIPTION = 'Create a PSR-15 request handler class file.';
 
+    /**
+     * @var string
+     */
     public const HELP = <<<'EOT'
         Creates a PSR-15 request handler class file named after the provided
         class. For a path, it matches the class namespace against PSR-4 autoloader
         namespaces in your composer.json.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_ARG_HANDLER = <<<'EOT'
         Fully qualified class name of the request handler to create. This value
         should be quoted to ensure namespace separators are not interpreted as
         escape sequences by your shell.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_OPT_NO_FACTORY = <<<'EOT'
         By default, this command generates a factory for the request handler it
         creates, and registers it with the container. Passing this option disables
         that feature.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_OPT_NO_REGISTER = <<<'EOT'
         By default, when this command generates a factory for the request handler it
         creates, it registers it with the container. Passing this option disables
         registration of the generated factory with the container.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_OPTION_WITHOUT_TEMPLATE = <<<'EOT'
         By default, this command generates a template for the newly generated class,
         and adds functionality to it render the template. Passing this flag
         disables template generation and invocation.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_OPTION_WITH_TEMPLATE_EXTENSION = <<<'EOT'
         By default, this command will look for a template file extension name
         first via the "templates.extension" configuration directive, and then
@@ -62,6 +86,9 @@ class CreateHandlerCommand extends Command
         may pass this option to specify a custom extension in that case.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_OPTION_WITH_TEMPLATE_NAME = <<<'EOT'
         By default, this command uses a normalized version of the class name as the
         template name. Use this option to provide an alternative template name
@@ -70,6 +97,9 @@ class CreateHandlerCommand extends Command
         renderer.  If --without-template is provided, this option is ignored. 
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_OPTION_WITH_TEMPLATE_NAMESPACE = <<<'EOT'
         By default, this command uses a normalized version of the root namespace of the
         class generated as the template namespace.  Use this option to provide an
@@ -79,6 +109,9 @@ class CreateHandlerCommand extends Command
         --without-template is provided, this option is ignored.
         EOT;
 
+    /**
+     * @var string
+     */
     public const STATUS_TEMPLATE = '<info>Creating request handler %s...</info>';
 
     /** @var null|string Cannot be defined explicitly due to parent class */
@@ -101,14 +134,6 @@ class CreateHandlerCommand extends Command
      */
     protected $requireHandlerBeforeGeneratingFactory = true;
 
-    private ContainerInterface $container;
-
-    /**
-     * Root path of the project. Defaults to getcwd(). Mainly exists for
-     * testing purposes, to allow injecting a virtual filesystem location.
-     */
-    private string $projectRoot;
-
     /**
      * Whether or not the template renderer is registered in the container.
      */
@@ -119,10 +144,14 @@ class CreateHandlerCommand extends Command
      */
     private bool $templateRendererIsRegistered = false;
 
-    public function __construct(ContainerInterface $container, string $projectRoot)
-    {
-        $this->projectRoot          = $projectRoot;
-        $this->container            = $container;
+    /**
+     * Root path of the project. Defaults to getcwd(). Mainly exists for
+     * testing purposes, to allow injecting a virtual filesystem location.
+     */
+    public function __construct(
+        private ContainerInterface $container,
+        private string $projectRoot
+    ) {
         $this->rendererIsRegistered = $this->containerDefinesRendererService($container);
 
         // Must do last, so that container and/or project root are in scope

--- a/src/CreateHandler/CreateTemplate.php
+++ b/src/CreateHandler/CreateTemplate.php
@@ -182,15 +182,9 @@ final class CreateTemplate
      */
     private function getDefaultTemplateSuffix(string $type): string
     {
-        switch ($type) {
-            case TwigRenderer::class:
-                return 'html.twig';
-            case PlatesRenderer::class:
-                // fall-through
-            case LaminasViewRenderer::class:
-                // fall-through
-            default:
-                return 'phtml';
-        }
+        return match ($type) {
+            TwigRenderer::class => 'html.twig',
+            default => 'phtml',
+        };
     }
 }

--- a/src/CreateHandler/CreateTemplate.php
+++ b/src/CreateHandler/CreateTemplate.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Tooling\CreateHandler;
 
+use ArrayAccess;
 use Mezzio\LaminasView\LaminasViewRenderer;
 use Mezzio\Plates\PlatesRenderer;
 use Mezzio\Tooling\TemplateResolutionTrait;
@@ -15,6 +16,7 @@ use function array_shift;
 use function count;
 use function file_put_contents;
 use function in_array;
+use function is_countable;
 use function is_dir;
 use function ltrim;
 use function mkdir;
@@ -39,18 +41,14 @@ final class CreateTemplate
         LaminasViewRenderer::class,
     ];
 
-    private ContainerInterface $container;
-
     /**
      * Root directory of project; used to determine if handler path indicates a
      * module.
      */
-    private string $projectPath;
-
-    public function __construct(string $projectPath, ContainerInterface $container)
-    {
-        $this->projectPath = $projectPath;
-        $this->container   = $container;
+    public function __construct(
+        private string $projectPath,
+        private ContainerInterface $container
+    ) {
     }
 
     public function forHandler(string $handler): Template
@@ -108,10 +106,8 @@ final class CreateTemplate
 
         // We only need to test for a known renderer type if there is no
         // template suffix available.
-        if (null === $templateSuffix) {
-            if (! in_array($type, self::KNOWN_RENDERERS, true)) {
-                throw UnresolvableRendererException::dueToUnknownType($type);
-            }
+        if (null === $templateSuffix && ! in_array($type, self::KNOWN_RENDERERS, true)) {
+            throw UnresolvableRendererException::dueToUnknownType($type);
         }
 
         return $type;
@@ -121,7 +117,7 @@ final class CreateTemplate
     {
         $r    = new ReflectionClass($handler);
         $path = $r->getFileName();
-        $path = preg_replace('#^' . preg_quote($this->projectPath) . '#', '', $path);
+        $path = preg_replace('#^' . preg_quote($this->projectPath, '#') . '#', '', $path);
         $path = ltrim($path, '/\\');
         return rtrim($path, '/\\');
     }
@@ -129,22 +125,24 @@ final class CreateTemplate
     /**
      * @todo If more than one template path exists, we should likely prompt the
      *     user for which one to which to install the template.
-     * @param array|ArrayAccess $config
      * @return null|string Returns null if no template path configuration
      *     exists for the namespace.
      * @throws TemplatePathResolutionException If configuration has zero paths
      *     defined for the namespace.
      */
-    private function getTemplatePathForNamespaceFromConfig(string $templateNamespace, $config): ?string
-    {
+    private function getTemplatePathForNamespaceFromConfig(
+        string $templateNamespace,
+        array|ArrayAccess $config
+    ): ?string {
         if (! isset($config['templates']['paths'][$templateNamespace])) {
             return null;
         }
 
         $paths = $config['templates']['paths'][$templateNamespace];
-        if (count($paths) === 0) {
+        if ((is_countable($paths) ? count($paths) : 0) === 0) {
             throw TemplatePathResolutionException::forNamespace($templateNamespace);
         }
+
         $path = array_shift($paths);
         return rtrim($path, '/\\');
     }
@@ -157,6 +155,7 @@ final class CreateTemplate
         if ($this->pathRepresentsModule($path, $namespace)) {
             return sprintf('%s/src/%s/templates', $this->projectPath, $namespace);
         }
+
         return sprintf('%s/templates/%s', $this->projectPath, $templateNamespace);
     }
 
@@ -173,6 +172,7 @@ final class CreateTemplate
         if (! isset($config['templates']['extension'])) {
             return $this->getDefaultTemplateSuffix($type);
         }
+
         return $config['templates']['extension'];
     }
 

--- a/src/CreateHandler/Template.php
+++ b/src/CreateHandler/Template.php
@@ -9,14 +9,8 @@ namespace Mezzio\Tooling\CreateHandler;
  */
 final class Template
 {
-    private string $name;
-
-    private string $path;
-
-    public function __construct(string $path, string $name)
+    public function __construct(private string $path, private string $name)
     {
-        $this->path = $path;
-        $this->name = $name;
     }
 
     public function getName(): string

--- a/src/CreateMiddleware/CreateMiddlewareCommand.php
+++ b/src/CreateMiddleware/CreateMiddlewareCommand.php
@@ -15,25 +15,40 @@ use function sprintf;
 
 final class CreateMiddlewareCommand extends Command
 {
+    /**
+     * @var string
+     */
     public const DEFAULT_SRC = '/src';
 
+    /**
+     * @var string
+     */
     public const HELP = <<<'EOT'
         Creates a PSR-15 middleware class file named after the provided class. For a
         path, it matches the class namespace against PSR-4 autoloader namespaces in
         your composer.json.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_ARG_MIDDLEWARE = <<<'EOT'
         Fully qualified class name of the middleware to create. This value
         should be quoted to ensure namespace separators are not interpreted as
         escape sequences by your shell.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_OPT_NO_FACTORY = <<<'EOT'
         By default, this command generates a factory for the middleware it creates, and
         registers it with the container. Passing this option disables that feature.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_OPT_NO_REGISTER = <<<'EOT'
         By default, when this command generates a factory for the middleware it
         creates, it registers it with the container. Passing this option disables
@@ -43,8 +58,6 @@ final class CreateMiddlewareCommand extends Command
     /** @var null|string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:middleware:create';
 
-    private string $projectRoot;
-
     /**
      * Flag indicating whether or not to require the generated middleware before
      * generating its factory. By default, this is true, as it is necessary
@@ -53,10 +66,8 @@ final class CreateMiddlewareCommand extends Command
      */
     private bool $requireMiddlewareBeforeGeneratingFactory = true;
 
-    public function __construct(string $projectRoot)
+    public function __construct(private string $projectRoot)
     {
-        $this->projectRoot = $projectRoot;
-
         parent::__construct();
     }
 
@@ -97,6 +108,7 @@ final class CreateMiddlewareCommand extends Command
             if ($this->requireMiddlewareBeforeGeneratingFactory) {
                 require $path;
             }
+
             return $this->generateFactory($middleware, $input, $output);
         }
 

--- a/src/Factory/ConfigInjector.php
+++ b/src/Factory/ConfigInjector.php
@@ -26,8 +26,14 @@ use const SORT_NATURAL;
  */
 final class ConfigInjector
 {
+    /**
+     * @var string
+     */
     public const CONFIG_FILE = 'config/autoload/mezzio-tooling-factories.global.php';
 
+    /**
+     * @var string
+     */
     public const TEMPLATE = <<<'EOT'
         <?php
         
@@ -95,6 +101,7 @@ final class ConfigInjector
 
             $normalized[] = sprintf('%s%s => %s', str_repeat(' ', 12), $class, $factory);
         }
+
         return implode(",\n", $normalized);
     }
 }

--- a/src/Factory/Create.php
+++ b/src/Factory/Create.php
@@ -19,11 +19,8 @@ use function substr;
 /** @internal */
 class Create
 {
-    private FactoryClassGenerator $generator;
-
-    public function __construct(FactoryClassGenerator $generator)
+    public function __construct(private FactoryClassGenerator $generator)
     {
-        $this->generator = $generator;
     }
 
     /**

--- a/src/Factory/CreateFactoryCommand.php
+++ b/src/Factory/CreateFactoryCommand.php
@@ -15,13 +15,22 @@ use function sprintf;
 
 final class CreateFactoryCommand extends Command
 {
+    /**
+     * @var string
+     */
     public const DEFAULT_SRC = '/src';
 
+    /**
+     * @var string
+     */
     public const HELP = <<<'EOT'
         Creates a factory class file for generating the provided class, in the
         same directory as the provided class.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_ARG_CLASS = <<<'EOT'
         Fully qualified class name of the class for which to create a factory.
         This value should be quoted to ensure namespace separators are not
@@ -29,6 +38,9 @@ final class CreateFactoryCommand extends Command
         autoloadable.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_OPT_NO_REGISTER = <<<'EOT'
         When this flag is present, the command WILL NOT register the factory
         with the application container.
@@ -37,15 +49,8 @@ final class CreateFactoryCommand extends Command
     /** @var null|string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:factory:create';
 
-    private Create $generator;
-
-    private string $projectRoot;
-
-    public function __construct(Create $generator, string $projectRoot)
+    public function __construct(private Create $generator, private string $projectRoot)
     {
-        $this->generator   = $generator;
-        $this->projectRoot = $projectRoot;
-
         parent::__construct();
     }
 

--- a/src/Factory/FactoryClassGenerator.php
+++ b/src/Factory/FactoryClassGenerator.php
@@ -75,6 +75,7 @@ class FactoryClassGenerator
 
     /**
      * @throws UnidentifiedTypeException If a parameter defines a non-class typehint.
+     * @return mixed[]
      */
     private function getConstructorParameters(string $className): array
     {
@@ -92,13 +93,15 @@ class FactoryClassGenerator
 
         $constructorParameters = array_filter(
             $constructorParameters,
-            static function (ReflectionParameter $argument) {
+            static function (ReflectionParameter $argument): bool {
                 if ($argument->isOptional()) {
                     return false;
                 }
+
                 if (null === $argument->getType()) {
                     throw UnidentifiedTypeException::forArgument($argument->getName());
                 }
+
                 return true;
             }
         );
@@ -122,13 +125,13 @@ class FactoryClassGenerator
     private function formatImportStatements(array $imports): string
     {
         natsort($imports);
-        $imports = array_map(static fn($import) => sprintf('use %s;', $import), $imports);
+        $imports = array_map(static fn($import): string => sprintf('use %s;', $import), $imports);
         return implode("\n", $imports);
     }
 
     private function createArgumentString(array $arguments): string
     {
-        $arguments = array_map(static fn($argument) => sprintf('$container->get(%s::class)', $argument), $arguments);
+        $arguments = array_map(static fn($argument): string => sprintf('$container->get(%s::class)', $argument), $arguments);
         switch (count($arguments)) {
             case 0:
                 return '';

--- a/src/Factory/FactoryClassGenerator.php
+++ b/src/Factory/FactoryClassGenerator.php
@@ -23,6 +23,9 @@ use function substr;
 /** @internal */
 class FactoryClassGenerator
 {
+    /**
+     * @var string
+     */
     public const FACTORY_TEMPLATE = <<<'EOT'
         <?php
 
@@ -77,32 +80,30 @@ class FactoryClassGenerator
     {
         $reflectionClass = new ReflectionClass($className);
 
-        if (! $reflectionClass->getConstructor()) {
+        if ($reflectionClass->getConstructor() === null) {
             return [];
         }
 
         $constructorParameters = $reflectionClass->getConstructor()->getParameters();
 
-        if (! $constructorParameters) {
+        if ($constructorParameters === []) {
             return [];
         }
 
         $constructorParameters = array_filter(
             $constructorParameters,
-            function (ReflectionParameter $argument) {
+            static function (ReflectionParameter $argument) {
                 if ($argument->isOptional()) {
                     return false;
                 }
-
                 if (null === $argument->getType()) {
                     throw UnidentifiedTypeException::forArgument($argument->getName());
                 }
-
                 return true;
             }
         );
 
-        if (! $constructorParameters) {
+        if ($constructorParameters === []) {
             return [];
         }
 

--- a/src/Factory/UnidentifiedTypeException.php
+++ b/src/Factory/UnidentifiedTypeException.php
@@ -13,8 +13,7 @@ final class UnidentifiedTypeException extends RuntimeException
     public static function forArgument(string $argument): self
     {
         return new self(sprintf(
-            'Cannot identify type for constructor argument "%s"; '
-            . 'no type hint, or non-class/interface type hint',
+            'Cannot identify type for constructor argument "%s"; no type hint, or non-class/interface type hint',
             $argument
         ));
     }

--- a/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
+++ b/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
@@ -43,12 +43,15 @@ final class ConvertInteropMiddleware
         if (! $file->isFile()) {
             return false;
         }
+
         if ($file->getExtension() !== 'php') {
             return false;
         }
+
         if (! $file->isReadable()) {
             return false;
         }
+
         return $file->isWritable();
     }
 

--- a/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
+++ b/src/MigrateInteropMiddleware/ConvertInteropMiddleware.php
@@ -20,11 +20,8 @@ use function str_replace;
 
 final class ConvertInteropMiddleware
 {
-    private OutputInterface $output;
-
-    public function __construct(OutputInterface $output)
+    public function __construct(private OutputInterface $output)
     {
-        $this->output = $output;
     }
 
     public function process(string $directory): void
@@ -43,10 +40,16 @@ final class ConvertInteropMiddleware
 
     private function isPhpFile(SplFileInfo $file): bool
     {
-        return $file->isFile()
-            && $file->getExtension() === 'php'
-            && $file->isReadable()
-            && $file->isWritable();
+        if (! $file->isFile()) {
+            return false;
+        }
+        if ($file->getExtension() !== 'php') {
+            return false;
+        }
+        if (! $file->isReadable()) {
+            return false;
+        }
+        return $file->isWritable();
     }
 
     private function processFile(string $filename): void

--- a/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
+++ b/src/MigrateInteropMiddleware/MigrateInteropMiddlewareCommand.php
@@ -14,8 +14,14 @@ use function sprintf;
 
 final class MigrateInteropMiddlewareCommand extends Command
 {
+    /**
+     * @var string
+     */
     private const DEFAULT_SRC = '/src';
 
+    /**
+     * @var string
+     */
     private const HELP = <<<'EOT'
         Migrate an Mezzio application to PSR-15 middleware.
         
@@ -28,6 +34,9 @@ final class MigrateInteropMiddlewareCommand extends Command
         mezzio-tooling.
         EOT;
 
+    /**
+     * @var string
+     */
     private const HELP_OPT_SRC = <<<'EOT'
         Specify a path to PHP files to migrate interop middleware.
         If not specified, assumes src/ under the current working path.
@@ -36,13 +45,8 @@ final class MigrateInteropMiddlewareCommand extends Command
     /** @var null|string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:middleware:migrate-from-interop';
 
-    /** @var null|string Path from which to resolve default src directory */
-    private ?string $projectRoot;
-
-    public function __construct(string $projectRoot)
+    public function __construct(private ?string $projectRoot)
     {
-        $this->projectRoot = $projectRoot;
-
         parent::__construct();
     }
 

--- a/src/MigrateMiddlewareToRequestHandler/ConvertMiddleware.php
+++ b/src/MigrateMiddlewareToRequestHandler/ConvertMiddleware.php
@@ -18,11 +18,8 @@ use function sprintf;
 
 final class ConvertMiddleware
 {
-    private OutputInterface $output;
-
-    public function __construct(OutputInterface $output)
+    public function __construct(private OutputInterface $output)
     {
-        $this->output = $output;
     }
 
     public function process(string $directory): void
@@ -41,10 +38,16 @@ final class ConvertMiddleware
 
     private function isPhpFile(SplFileInfo $file): bool
     {
-        return $file->isFile()
-            && $file->getExtension() === 'php'
-            && $file->isReadable()
-            && $file->isWritable();
+        if (! $file->isFile()) {
+            return false;
+        }
+        if ($file->getExtension() !== 'php') {
+            return false;
+        }
+        if (! $file->isReadable()) {
+            return false;
+        }
+        return $file->isWritable();
     }
 
     private function processFile(string $filename): void

--- a/src/MigrateMiddlewareToRequestHandler/ConvertMiddleware.php
+++ b/src/MigrateMiddlewareToRequestHandler/ConvertMiddleware.php
@@ -41,12 +41,15 @@ final class ConvertMiddleware
         if (! $file->isFile()) {
             return false;
         }
+
         if ($file->getExtension() !== 'php') {
             return false;
         }
+
         if (! $file->isReadable()) {
             return false;
         }
+
         return $file->isWritable();
     }
 

--- a/src/MigrateMiddlewareToRequestHandler/MigrateMiddlewareToRequestHandlerCommand.php
+++ b/src/MigrateMiddlewareToRequestHandler/MigrateMiddlewareToRequestHandlerCommand.php
@@ -14,8 +14,14 @@ use function sprintf;
 
 final class MigrateMiddlewareToRequestHandlerCommand extends Command
 {
+    /**
+     * @var string
+     */
     private const DEFAULT_SRC = '/src';
 
+    /**
+     * @var string
+     */
     private const HELP = <<<'EOT'
         Migrate PSR-15 middleware to request handlers.
         
@@ -25,6 +31,9 @@ final class MigrateMiddlewareToRequestHandlerCommand extends Command
         handlers.
         EOT;
 
+    /**
+     * @var string
+     */
     private const HELP_OPT_SRC = <<<'EOT'
         Specify a path to PHP files under which to migrate PSR-15 middleware to request
         handlers. If not specified, assumes src/ under the current working path.
@@ -33,16 +42,11 @@ final class MigrateMiddlewareToRequestHandlerCommand extends Command
     /** @var null|string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:middleware:to-request-handler';
 
-    /** @var string Path from which to resolve default src directory */
-    private string $projectRoot;
-
     /**
      * @var null|string Project root against which to scan.
      */
-    public function __construct(string $projectRoot)
+    public function __construct(private string $projectRoot)
     {
-        $this->projectRoot = $projectRoot;
-
         parent::__construct();
     }
 

--- a/src/Module/CommandCommonOptions.php
+++ b/src/Module/CommandCommonOptions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Tooling\Module;
 
+use ArrayAccess;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -45,15 +46,12 @@ final class CommandCommonOptions
 
     /**
      * Retrieve the modules path from  1: $input, 2: project config or 3: default 'src'
-     *
-     * @param array|ArrayAccess $config
      */
-    public static function getModulesPath(InputInterface $input, $config = []): string
+    public static function getModulesPath(InputInterface $input, array|ArrayAccess $config = []): string
     {
         $configuredModulesPath = $config[self::class]['--modules-path'] ?? 'src';
         $modulesPath           = $input->getOption('modules-path') ?? $configuredModulesPath;
-        $modulesPath           = preg_replace('/^\.\//', '', str_replace('\\', '/', $modulesPath));
 
-        return $modulesPath;
+        return preg_replace('#^\.\/#', '', str_replace('\\', '/', $modulesPath));
     }
 }

--- a/src/Module/Create.php
+++ b/src/Module/Create.php
@@ -11,14 +11,17 @@ use function file_put_contents;
 use function ltrim;
 use function rtrim;
 use function sprintf;
+use function str_starts_with;
 use function strlen;
-use function strpos;
 use function substr;
 
 final class Create
 {
     use TemplateResolutionTrait;
 
+    /**
+     * @var string
+     */
     public const TEMPLATE_CONFIG_PROVIDER_FLAT = <<<'EOT'
         <?php
         
@@ -62,6 +65,9 @@ final class Create
         
         EOT;
 
+    /**
+     * @var string
+     */
     public const TEMPLATE_CONFIG_PROVIDER_RECOMMENDED = <<<'EOT'
         <?php
         
@@ -118,6 +124,9 @@ final class Create
         
         EOT;
 
+    /**
+     * @var string
+     */
     public const TEMPLATE_ROUTE_DELEGATOR_CONFIG = <<<'EOT'
         
                     'delegators' => [
@@ -127,6 +136,9 @@ final class Create
                     ],
         EOT;
 
+    /**
+     * @var string
+     */
     public const TEMPLATE_ROUTE_DELEGATOR = <<<'EOT'
         <?php
         
@@ -158,11 +170,8 @@ final class Create
 
         EOT;
 
-    private bool $useFlatStructure;
-
-    public function __construct(bool $useFlatStructure = false)
+    public function __construct(private bool $useFlatStructure = false)
     {
-        $this->useFlatStructure = $useFlatStructure;
     }
 
     /**
@@ -293,7 +302,7 @@ final class Create
 
     private function stripProjectRootFromPath(string $projectRoot, string $path): string
     {
-        if (0 !== strpos($path, $projectRoot)) {
+        if (! str_starts_with($path, $projectRoot)) {
             return $path;
         }
 

--- a/src/Module/CreateCommand.php
+++ b/src/Module/CreateCommand.php
@@ -15,6 +15,9 @@ use function sprintf;
 
 final class CreateCommand extends Command
 {
+    /**
+     * @var string
+     */
     public const HELP = <<<'EOT'
         Create a new middleware module for the application.
         
@@ -26,22 +29,17 @@ final class CreateCommand extends Command
           configuration.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_ARG_MODULE = 'The module to create and register with the application.';
 
     /** @var null|string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:module:create';
 
-    /** @var array|ArrayAccess */
-    private $config;
-
-    private string $projectRoot;
-
     /** @param array|ArrayAccess $config */
-    public function __construct($config, string $projectRoot)
+    public function __construct(private $config, private string $projectRoot)
     {
-        $this->config      = $config;
-        $this->projectRoot = $projectRoot;
-
         parent::__construct();
     }
 

--- a/src/Module/DeregisterCommand.php
+++ b/src/Module/DeregisterCommand.php
@@ -18,6 +18,9 @@ use function sprintf;
 
 final class DeregisterCommand extends Command
 {
+    /**
+     * @var string
+     */
     public const HELP = <<<'EOT'
         Deregister an existing middleware module from the application, by:
 
@@ -27,6 +30,9 @@ final class DeregisterCommand extends Command
           application configuration.
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_ARG_MODULE = 'The module to register with the application';
 
     /** @var null|string Cannot be defined explicitly due to parent class */
@@ -34,22 +40,16 @@ final class DeregisterCommand extends Command
 
     private ComposerPackageInterface $package;
 
-    private string $projectRoot;
-
-    private ComposerProcessFactoryInterface $processFactory;
-
     private InjectorInterface $injector;
 
     public function __construct(
-        string $projectRoot,
+        private string $projectRoot,
         ComposerPackageFactoryInterface $packageFactory,
-        ComposerProcessFactoryInterface $processFactory,
+        private ComposerProcessFactoryInterface $processFactory,
         ?InjectorInterface $configInjector = null
     ) {
-        $this->projectRoot    = $projectRoot;
-        $this->package        = $packageFactory->loadPackage($projectRoot);
-        $this->processFactory = $processFactory;
-        $this->injector       = $configInjector ?? new ConfigAggregatorInjector($this->projectRoot);
+        $this->package  = $packageFactory->loadPackage($projectRoot);
+        $this->injector = $configInjector ?? new ConfigAggregatorInjector($this->projectRoot);
 
         parent::__construct();
     }

--- a/src/Module/ModuleMetadata.php
+++ b/src/Module/ModuleMetadata.php
@@ -8,19 +8,13 @@ use function preg_replace;
 
 final class ModuleMetadata
 {
-    private string $name;
-
-    private string $rootPath;
-
     private string $sourcePath;
 
     public function __construct(
-        string $name,
-        string $rootPath,
+        private string $name,
+        private string $rootPath,
         string $sourcePath
     ) {
-        $this->name       = $name;
-        $this->rootPath   = $rootPath;
         $this->sourcePath = preg_replace('#^\./#', '', $sourcePath);
     }
 

--- a/src/Module/RegisterCommand.php
+++ b/src/Module/RegisterCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mezzio\Tooling\Module;
 
 use Mezzio\Tooling\Composer\ComposerPackageFactoryInterface;
+use Mezzio\Tooling\Composer\ComposerPackageInterface;
 use Mezzio\Tooling\Composer\ComposerProcessFactoryInterface;
 use Mezzio\Tooling\ConfigInjector\ConfigAggregatorInjector;
 use Mezzio\Tooling\ConfigInjector\InjectorInterface;
@@ -44,8 +45,7 @@ final class RegisterCommand extends Command
     /** @var null|string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:module:register';
 
-    /** @var ComposerPackageInterface */
-    private $package;
+    private ComposerPackageInterface $package;
 
     private InjectorInterface $injector;
 

--- a/src/Module/RegisterCommand.php
+++ b/src/Module/RegisterCommand.php
@@ -19,6 +19,9 @@ use function sprintf;
 
 final class RegisterCommand extends Command
 {
+    /**
+     * @var string
+     */
     public const HELP = <<<'EOT'
         Register an existing middleware module with the application, by:
         
@@ -33,6 +36,9 @@ final class RegisterCommand extends Command
 
         EOT;
 
+    /**
+     * @var string
+     */
     public const HELP_ARG_MODULE = 'The module to register with the application';
 
     /** @var null|string Cannot be defined explicitly due to parent class */
@@ -41,21 +47,16 @@ final class RegisterCommand extends Command
     /** @var ComposerPackageInterface */
     private $package;
 
-    private string $projectRoot;
-
-    private ComposerProcessFactoryInterface $processFactory;
     private InjectorInterface $injector;
 
     public function __construct(
-        string $projectRoot,
+        private string $projectRoot,
         ComposerPackageFactoryInterface $packageFactory,
-        ComposerProcessFactoryInterface $processFactory,
+        private ComposerProcessFactoryInterface $processFactory,
         ?InjectorInterface $configInjector = null
     ) {
-        $this->projectRoot    = $projectRoot;
-        $this->package        = $packageFactory->loadPackage($projectRoot);
-        $this->processFactory = $processFactory;
-        $this->injector       = $configInjector ?? new ConfigAggregatorInjector($this->projectRoot);
+        $this->package  = $packageFactory->loadPackage($projectRoot);
+        $this->injector = $configInjector ?? new ConfigAggregatorInjector($this->projectRoot);
 
         parent::__construct();
     }

--- a/src/TemplateResolutionTrait.php
+++ b/src/TemplateResolutionTrait.php
@@ -7,8 +7,8 @@ namespace Mezzio\Tooling;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerInterface;
 
-use function get_class;
 use function preg_replace;
+use function str_contains;
 use function strpos;
 use function strrpos;
 use function strtolower;
@@ -53,7 +53,7 @@ trait TemplateResolutionTrait
      */
     private function getClassName(string $class): string
     {
-        return strpos($class, '\\') !== false
+        return str_contains($class, '\\')
             ? substr($class, strrpos($class, '\\') + 1)
             : $class;
     }
@@ -87,7 +87,8 @@ trait TemplateResolutionTrait
         if (! $container->has(TemplateRendererInterface::class)) {
             return null;
         }
+
         $renderer = $container->get(TemplateRendererInterface::class);
-        return get_class($renderer);
+        return $renderer::class;
     }
 }

--- a/test/Composer/FileSystemBasedComposerPackageTest.php
+++ b/test/Composer/FileSystemBasedComposerPackageTest.php
@@ -59,6 +59,9 @@ class FileSystemBasedComposerPackageTest extends TestCase
         return $path;
     }
 
+    /**
+     * @return mixed[]
+     */
     public function getComposerJson(string $filename): array
     {
         $json = file_get_contents($filename);

--- a/test/Composer/FileSystemBasedComposerPackageTest.php
+++ b/test/Composer/FileSystemBasedComposerPackageTest.php
@@ -20,12 +20,12 @@ use const JSON_THROW_ON_ERROR;
 
 class FileSystemBasedComposerPackageTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->tearDownAssets();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->tearDownAssets();
     }

--- a/test/ConfigDiscovery/ConfigAggregatorTest.php
+++ b/test/ConfigDiscovery/ConfigAggregatorTest.php
@@ -11,11 +11,9 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigAggregatorTest extends TestCase
 {
-    /** @var vfsStreamDirectory */
-    private $configDir;
+    private vfsStreamDirectory $configDir;
 
-    /** @var ConfigAggregator */
-    private $locator;
+    private ConfigAggregator $locator;
 
     protected function setUp(): void
     {
@@ -34,7 +32,8 @@ class ConfigAggregatorTest extends TestCase
     {
         vfsStream::newFile('config/config.php')
             ->at($this->configDir)
-            ->setContent('<' . "?php\nreturn [];");
+            ->setContent('<?php
+return [];');
         $this->assertFalse($this->locator->locate());
     }
 
@@ -47,12 +46,24 @@ class ConfigAggregatorTest extends TestCase
     {
         // @codingStandardsIgnoreStart
         return [
-            'fqcn-short-array'               => ['<' . "?php\n\$aggregator = new Laminas\ConfigAggregator\ConfigAggregator([\n]);"],
-            'globally-qualified-short-array' => ['<' . "?php\n\$aggregator = new \Laminas\ConfigAggregator\ConfigAggregator([\n]);"],
-            'imported-short-array'           => ['<' . "?php\n\$aggregator = new ConfigAggregator([\n]);"],
-            'fqcn-long-array'                => ['<' . "?php\n\$aggregator = new Laminas\ConfigAggregator\ConfigAggregator(array(\n));"],
-            'globally-qualified-long-array'  => ['<' . "?php\n\$aggregator = new \Laminas\ConfigAggregator\ConfigAggregator(array(\n));"],
-            'imported-long-array'            => ['<' . "?php\n\$aggregator = new ConfigAggregator(array(\n));"],
+            'fqcn-short-array'               => ['<?php
+$aggregator = new Laminas\ConfigAggregator\ConfigAggregator([
+]);'],
+            'globally-qualified-short-array' => ['<?php
+$aggregator = new \Laminas\ConfigAggregator\ConfigAggregator([
+]);'],
+            'imported-short-array'           => ['<?php
+$aggregator = new ConfigAggregator([
+]);'],
+            'fqcn-long-array'                => ['<?php
+$aggregator = new Laminas\ConfigAggregator\ConfigAggregator(array(
+));'],
+            'globally-qualified-long-array'  => ['<?php
+$aggregator = new \Laminas\ConfigAggregator\ConfigAggregator(array(
+));'],
+            'imported-long-array'            => ['<?php
+$aggregator = new ConfigAggregator(array(
+));'],
         ];
         // @codingStandardsIgnoreEnd
     }

--- a/test/ConfigInjector/ConfigAggregatorInjectorTest.php
+++ b/test/ConfigInjector/ConfigAggregatorInjectorTest.php
@@ -30,11 +30,14 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         InjectorInterface::TYPE_CONFIG_PROVIDER,
     ];
 
-    public function convertToShortArraySyntax(string $contents): string
+    public function convertToShortArraySyntax(string $contents): ?string
     {
         return preg_replace('#array\(([^)]+)\)#s', '[$1]', $contents);
     }
 
+    /**
+     * @return array<string, mixed[]>
+     */
     public function allowedTypes(): array
     {
         return [
@@ -44,6 +47,9 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
+    /**
+     * @return array<string, array<string|bool|int>>
+     */
     public function injectComponentProvider(): array
     {
         // phpcs:disable Generic.Files.LineLength.TooLong
@@ -86,6 +92,9 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         // phpcs:enable
     }
 
+    /**
+     * @return array<string, array<string|bool|int>>
+     */
     public function packageAlreadyRegisteredProvider(): array
     {
         // phpcs:disable Generic.Files.LineLength.TooLong
@@ -108,6 +117,9 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         // phpcs:enable
     }
 
+    /**
+     * @return array<string, array<string|bool>>
+     */
     public function emptyConfiguration(): array
     {
         // phpcs:disable Generic.Files.LineLength.TooLong
@@ -130,6 +142,9 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
+    /**
+     * @return array<string, array<string|bool>>
+     */
     public function packagePopulatedInConfiguration(): array
     {
         // phpcs:disable Generic.Files.LineLength.TooLong

--- a/test/ConfigInjector/ConfigAggregatorInjectorTest.php
+++ b/test/ConfigInjector/ConfigAggregatorInjectorTest.php
@@ -32,7 +32,7 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
 
     public function convertToShortArraySyntax(string $contents): string
     {
-        return preg_replace('/array\(([^)]+)\)/s', '[$1]', $contents);
+        return preg_replace('#array\(([^)]+)\)#s', '[$1]', $contents);
     }
 
     public function allowedTypes(): array

--- a/test/CreateHandler/CreateActionCommandTest.php
+++ b/test/CreateHandler/CreateActionCommandTest.php
@@ -34,13 +34,13 @@ class CreateActionCommandTest extends TestCase
     use ProphecyTrait;
 
     /** @psalm-var ObjectProphecy<ContainerInterface> */
-    private $container;
+    private ObjectProphecy $container;
 
     /** @psalm-var ObjectProphecy<InputInterface> */
-    private $input;
+    private ObjectProphecy $input;
 
     /** @psalm-var ObjectProphecy<ConsoleOutputInterface> */
-    private $output;
+    private ObjectProphecy $output;
 
     protected function setUp(): void
     {
@@ -78,14 +78,14 @@ class CreateActionCommandTest extends TestCase
     /**
      * @return ObjectProphecy<Application>
      */
-    private function mockApplication(string $forService = 'Foo\TestAction')
+    private function mockApplication(string $forService = 'Foo\TestAction'): ObjectProphecy
     {
         $helperSet = $this->prophesize(HelperSet::class)->reveal();
 
         $factoryCommand = $this->prophesize(Command::class);
         $factoryCommand
             ->run(
-                Argument::that(static function ($input) use ($forService) {
+                Argument::that(static function ($input) use ($forService): ArrayInput {
                     Assert::assertInstanceOf(ArrayInput::class, $input);
                     Assert::assertStringContainsString('mezzio:factory:create', (string) $input);
                     Assert::assertStringContainsString($forService, (string) $input);

--- a/test/CreateHandler/CreateActionCommandTest.php
+++ b/test/CreateHandler/CreateActionCommandTest.php
@@ -85,7 +85,7 @@ class CreateActionCommandTest extends TestCase
         $factoryCommand = $this->prophesize(Command::class);
         $factoryCommand
             ->run(
-                Argument::that(function ($input) use ($forService) {
+                Argument::that(static function ($input) use ($forService) {
                     Assert::assertInstanceOf(ArrayInput::class, $input);
                     Assert::assertStringContainsString('mezzio:factory:create', (string) $input);
                     Assert::assertStringContainsString($forService, (string) $input);
@@ -97,7 +97,7 @@ class CreateActionCommandTest extends TestCase
 
         $application = $this->prophesize(Application::class);
         $application->getHelperSet()->willReturn($helperSet);
-        $application->find('mezzio:factory:create')->will([$factoryCommand, 'reveal']);
+        $application->find('mezzio:factory:create')->will(static fn(): object => $factoryCommand->reveal());
 
         return $application;
     }

--- a/test/CreateHandler/CreateActionCommandTest.php
+++ b/test/CreateHandler/CreateActionCommandTest.php
@@ -10,10 +10,8 @@ use Mezzio\Tooling\CreateHandler\CreateHandler;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -31,29 +29,27 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 class CreateActionCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
-    use ProphecyTrait;
 
-    /** @psalm-var ObjectProphecy<ContainerInterface> */
-    private ObjectProphecy $container;
+    /** @psalm-var ContainerInterface&MockObject */
+    private ContainerInterface $container;
 
-    /** @psalm-var ObjectProphecy<InputInterface> */
-    private ObjectProphecy $input;
+    /** @psalm-var InputInterface&MockObject */
+    private InputInterface $input;
 
-    /** @psalm-var ObjectProphecy<ConsoleOutputInterface> */
-    private ObjectProphecy $output;
+    /** @psalm-var ConsoleOutputInterface&MockObject */
+    private ConsoleOutputInterface $output;
 
     protected function setUp(): void
     {
-        $this->input  = $this->prophesize(InputInterface::class);
-        $this->output = $this->prophesize(ConsoleOutputInterface::class);
-
-        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->input     = $this->createMock(InputInterface::class);
+        $this->output    = $this->createMock(ConsoleOutputInterface::class);
+        $this->container = $this->createMock(ContainerInterface::class);
     }
 
     private function createCommand(): CreateActionCommand
     {
         return new CreateActionCommand(
-            $this->container->reveal(),
+            $this->container,
             ''
         );
     }
@@ -75,50 +71,49 @@ class CreateActionCommandTest extends TestCase
         return $r;
     }
 
-    /**
-     * @return ObjectProphecy<Application>
-     */
-    private function mockApplication(string $forService = 'Foo\TestAction'): ObjectProphecy
+    /** @return Application&MockObject */
+    private function mockApplication(string $forService = 'Foo\TestAction'): Application
     {
-        $helperSet = $this->prophesize(HelperSet::class)->reveal();
+        $helperSet = $this->createMock(HelperSet::class);
 
-        $factoryCommand = $this->prophesize(Command::class);
+        $factoryCommand = $this->createMock(Command::class);
         $factoryCommand
-            ->run(
-                Argument::that(static function ($input) use ($forService): ArrayInput {
+            ->method('run')
+            ->with(
+                self::callback(static function ($input) use ($forService): bool {
                     Assert::assertInstanceOf(ArrayInput::class, $input);
                     Assert::assertStringContainsString('mezzio:factory:create', (string) $input);
                     Assert::assertStringContainsString($forService, (string) $input);
-                    return $input;
+                    return true;
                 }),
-                $this->output->reveal()
+                $this->output
             )
             ->willReturn(0);
 
-        $application = $this->prophesize(Application::class);
-        $application->getHelperSet()->willReturn($helperSet);
-        $application->find('mezzio:factory:create')->will(static fn(): object => $factoryCommand->reveal());
+        $application = $this->createMock(Application::class);
+        $application->method('getHelperSet')->willReturn($helperSet);
+        $application->method('find')->with('mezzio:factory:create')->willReturn($factoryCommand);
 
         return $application;
     }
 
     public function testConfigureSetsExpectedDescriptionWhenRequestingAnAction(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(false);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(false);
         $command = $this->createCommand();
         self::assertStringContainsString(CreateActionCommand::HELP_DESCRIPTION, $command->getDescription());
     }
 
     public function testConfigureSetsExpectedHelpWhenRequestingAnAction(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(false);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(false);
         $command = $this->createCommand();
         self::assertEquals(CreateActionCommand::HELP, $command->getHelp());
     }
 
     public function testConfigureSetsExpectedArgumentsWhenRequestingAnAction(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(false);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(false);
         $command    = $this->createCommand();
         $definition = $command->getDefinition();
         self::assertTrue($definition->hasArgument('action'));
@@ -129,7 +124,7 @@ class CreateActionCommandTest extends TestCase
 
     public function testConfigureSetsExpectedOptionsWhenRequestingAnAction(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(false);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(false);
         $command    = $this->createCommand();
         $definition = $command->getDefinition();
 
@@ -151,7 +146,7 @@ class CreateActionCommandTest extends TestCase
 
     public function testConfigureSetsExpectedTemplateOptionsWhenRequestingAnActionAndRendererIsPresent(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(true);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(true);
         $command    = $this->createCommand();
         $definition = $command->getDefinition();
 
@@ -178,10 +173,10 @@ class CreateActionCommandTest extends TestCase
 
     public function testSuccessfulExecutionEmitsExpectedMessagesWhenRequestingAnAction(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(false);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(false);
         $command = $this->createCommand();
         $this->disableRequireHandlerDirective($command);
-        $command->setApplication($this->mockApplication('Foo\TestAction')->reveal());
+        $command->setApplication($this->mockApplication('Foo\TestAction'));
 
         $generator = Mockery::mock('overload:' . CreateHandler::class);
         $generator->shouldReceive('process')
@@ -189,25 +184,26 @@ class CreateActionCommandTest extends TestCase
             ->with('Foo\TestAction', [])
             ->andReturn(__DIR__);
 
-        $this->input->getArgument('action')->willReturn('Foo\TestAction');
-        $this->input->getOption('no-factory')->willReturn(false);
-        $this->input->getOption('no-register')->willReturn(false);
+        $this->input->method('getArgument')->with('action')->willReturn('Foo\TestAction');
+        $this->input->method('getOption')->willReturnMap([
+            ['no-factory', false],
+            ['no-register', false],
+        ]);
         $this->output
-            ->writeln(Argument::containingString('Creating action Foo\TestAction'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Success'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Created class Foo\TestAction, in file ' . __DIR__))
-            ->shouldBeCalled();
+            ->expects(self::atLeast(3))
+            ->method('writeln')
+            ->with(self::logicalOr(
+                self::stringContains('Creating action Foo\TestAction'),
+                self::stringContains('Success'),
+                self::stringContains('Created class Foo\TestAction, in file ' . __DIR__)
+            ));
 
         $method = $this->reflectExecuteMethod($command);
 
         self::assertSame(0, $method->invoke(
             $command,
-            $this->input->reveal(),
-            $this->output->reveal()
+            $this->input,
+            $this->output
         ));
     }
 }

--- a/test/CreateHandler/CreateHandlerCommandTest.php
+++ b/test/CreateHandler/CreateHandlerCommandTest.php
@@ -45,7 +45,7 @@ class CreateHandlerCommandTest extends TestCase
     private ObjectProphecy $input;
 
     /** @var ObjectProphecy<ConsoleOutputInterface> */
-    private $output;
+    private ObjectProphecy $output;
 
     protected function setUp(): void
     {
@@ -83,14 +83,14 @@ class CreateHandlerCommandTest extends TestCase
     /**
      * @return ObjectProphecy<Application>
      */
-    private function mockApplication(string $forService = 'Foo\TestHandler')
+    private function mockApplication(string $forService = 'Foo\TestHandler'): ObjectProphecy
     {
         $helperSet = $this->prophesize(HelperSet::class)->reveal();
 
         $factoryCommand = $this->prophesize(Command::class);
         $factoryCommand
             ->run(
-                Argument::that(static function ($input) use ($forService) {
+                Argument::that(static function ($input) use ($forService): ArrayInput {
                     Assert::assertInstanceOf(ArrayInput::class, $input);
                     Assert::assertStringContainsString('mezzio:factory:create', (string) $input);
                     Assert::assertStringContainsString($forService, (string) $input);

--- a/test/CreateHandler/CreateHandlerCommandTest.php
+++ b/test/CreateHandler/CreateHandlerCommandTest.php
@@ -90,7 +90,7 @@ class CreateHandlerCommandTest extends TestCase
         $factoryCommand = $this->prophesize(Command::class);
         $factoryCommand
             ->run(
-                Argument::that(function ($input) use ($forService) {
+                Argument::that(static function ($input) use ($forService) {
                     Assert::assertInstanceOf(ArrayInput::class, $input);
                     Assert::assertStringContainsString('mezzio:factory:create', (string) $input);
                     Assert::assertStringContainsString($forService, (string) $input);

--- a/test/CreateHandler/CreateHandlerCommandTest.php
+++ b/test/CreateHandler/CreateHandlerCommandTest.php
@@ -13,10 +13,8 @@ use Mezzio\Tooling\CreateHandler\Template;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -36,29 +34,27 @@ use function sprintf;
 class CreateHandlerCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
-    use ProphecyTrait;
 
-    /** @var ObjectProphecy<ContainerInterface> */
-    private ObjectProphecy $container;
+    /** @var ContainerInterface&MockObject */
+    private ContainerInterface $container;
 
-    /** @var ObjectProphecy<InputInterface> */
-    private ObjectProphecy $input;
+    /** @var InputInterface&MockObject */
+    private InputInterface $input;
 
-    /** @var ObjectProphecy<ConsoleOutputInterface> */
-    private ObjectProphecy $output;
+    /** @var ConsoleOutputInterface&MockObject */
+    private ConsoleOutputInterface $output;
 
     protected function setUp(): void
     {
-        $this->input  = $this->prophesize(InputInterface::class);
-        $this->output = $this->prophesize(ConsoleOutputInterface::class);
-
-        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->input     = $this->createMock(InputInterface::class);
+        $this->output    = $this->createMock(ConsoleOutputInterface::class);
+        $this->container = $this->createMock(ContainerInterface::class);
     }
 
     private function createCommand(): CreateHandlerCommand
     {
         return new CreateHandlerCommand(
-            $this->container->reveal(),
+            $this->container,
             ''
         );
     }
@@ -80,50 +76,49 @@ class CreateHandlerCommandTest extends TestCase
         return $r;
     }
 
-    /**
-     * @return ObjectProphecy<Application>
-     */
-    private function mockApplication(string $forService = 'Foo\TestHandler'): ObjectProphecy
+    /** @return Application&MockObject */
+    private function mockApplication(string $forService = 'Foo\TestHandler'): Application
     {
-        $helperSet = $this->prophesize(HelperSet::class)->reveal();
+        $helperSet = $this->createMock(HelperSet::class);
 
-        $factoryCommand = $this->prophesize(Command::class);
+        $factoryCommand = $this->createMock(Command::class);
         $factoryCommand
-            ->run(
-                Argument::that(static function ($input) use ($forService): ArrayInput {
+            ->method('run')
+            ->with(
+                self::callback(static function ($input) use ($forService): bool {
                     Assert::assertInstanceOf(ArrayInput::class, $input);
                     Assert::assertStringContainsString('mezzio:factory:create', (string) $input);
                     Assert::assertStringContainsString($forService, (string) $input);
-                    return $input;
+                    return true;
                 }),
-                $this->output->reveal()
+                $this->output
             )
             ->willReturn(0);
 
-        $application = $this->prophesize(Application::class);
-        $application->getHelperSet()->willReturn($helperSet);
-        $application->find('mezzio:factory:create')->will([$factoryCommand, 'reveal']);
+        $application = $this->createMock(Application::class);
+        $application->method('getHelperSet')->willReturn($helperSet);
+        $application->method('find')->with('mezzio:factory:create')->willReturn($factoryCommand);
 
         return $application;
     }
 
     public function testConfigureSetsExpectedDescriptionWhenRequestingAHandler(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(false);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(false);
         $command = $this->createCommand();
         self::assertStringContainsString(CreateHandlerCommand::HELP_DESCRIPTION, $command->getDescription());
     }
 
     public function testConfigureSetsExpectedHelpWhenRequestingAHandler(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(true);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(true);
         $command = $this->createCommand();
         self::assertEquals(CreateHandlerCommand::HELP, $command->getHelp());
     }
 
     public function testConfigureSetsExpectedArguments(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(true);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(true);
         $command    = $this->createCommand();
         $definition = $command->getDefinition();
 
@@ -135,7 +130,7 @@ class CreateHandlerCommandTest extends TestCase
 
     public function testConfigureSetsExpectedOptionsWhenRequestingAHandler(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(false);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(false);
         $command    = $this->createCommand();
         $definition = $command->getDefinition();
 
@@ -157,8 +152,8 @@ class CreateHandlerCommandTest extends TestCase
 
     public function testConfigureSetsExpectedTemplateOptionsWhenRequestingAHandlerAndRendererIsPresent(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(true);
-        $command    = new CreateHandlerCommand($this->container->reveal(), '');
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(true);
+        $command    = new CreateHandlerCommand($this->container, '');
         $definition = $command->getDefinition();
 
         self::assertTrue($definition->hasOption('without-template'));
@@ -184,10 +179,10 @@ class CreateHandlerCommandTest extends TestCase
 
     public function testSuccessfulExecutionEmitsExpectedMessages(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(false);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(false);
         $command = $this->createCommand();
         $this->disableRequireHandlerDirective($command);
-        $command->setApplication($this->mockApplication()->reveal());
+        $command->setApplication($this->mockApplication());
 
         $generator = Mockery::mock('overload:' . CreateHandler::class);
         $generator->shouldReceive('process')
@@ -195,25 +190,27 @@ class CreateHandlerCommandTest extends TestCase
             ->with('Foo\TestHandler', [])
             ->andReturn(__DIR__);
 
-        $this->input->getArgument('handler')->willReturn('Foo\TestHandler');
-        $this->input->getOption('no-factory')->willReturn(false);
-        $this->input->getOption('no-register')->willReturn(false);
+        $this->input->method('getArgument')->with('handler')->willReturn('Foo\TestHandler');
+        $this->input->method('getOption')
+            ->willReturnMap([
+                ['no-factory', false],
+                ['no-register', false],
+            ]);
         $this->output
-            ->writeln(Argument::containingString('Creating request handler Foo\TestHandler'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Success'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Created class Foo\TestHandler, in file ' . __DIR__))
-            ->shouldBeCalled();
+            ->expects(self::atLeast(3))
+            ->method('writeln')
+            ->with(self::logicalOr(
+                self::stringContains('Creating request handler Foo\TestHandler'),
+                self::stringContains('Success'),
+                self::stringContains('Created class Foo\TestHandler, in file ' . __DIR__)
+            ));
 
         $method = $this->reflectExecuteMethod($command);
 
         self::assertSame(0, $method->invoke(
             $command,
-            $this->input->reveal(),
-            $this->output->reveal()
+            $this->input,
+            $this->output
         ));
     }
 
@@ -227,10 +224,10 @@ class CreateHandlerCommandTest extends TestCase
         $templateNamespace     = 'foo';
         $templateName          = 'test';
 
-        $this->container->has(TemplateRendererInterface::class)->willReturn(true);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(true);
         $command = $this->createCommand();
         $this->disableRequireHandlerDirective($command);
-        $command->setApplication($this->mockApplication()->reveal());
+        $command->setApplication($this->mockApplication());
 
         $generator = Mockery::mock('overload:' . CreateHandler::class);
         $generator->shouldReceive('process')
@@ -245,32 +242,32 @@ class CreateHandlerCommandTest extends TestCase
             ->with('Foo\TestHandler', $templateNamespace, $templateName, null)
             ->andReturn($template);
 
-        $this->input->getArgument('handler')->willReturn('Foo\TestHandler');
-        $this->input->getOption('without-template')->willReturn(false);
-        $this->input->getOption('with-template-namespace')->willReturn(null);
-        $this->input->getOption('with-template-name')->willReturn(null);
-        $this->input->getOption('with-template-extension')->willReturn(null);
-        $this->input->getOption('no-factory')->willReturn(false);
-        $this->input->getOption('no-register')->willReturn(false);
+        $this->input->method('getArgument')->with('handler')->willReturn('Foo\TestHandler');
+        $this->input->method('getOption')
+            ->willReturnMap([
+                ['without-template' => false],
+                ['with-template-namespace', null],
+                ['with-template-name', null],
+                ['with-template-extension', null],
+                ['no-factory', false],
+                ['no-register', false],
+            ]);
         $this->output
-            ->writeln(Argument::containingString('Creating request handler Foo\TestHandler'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Success'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Created template ' . $generatedTemplate . ' in file ' . __FILE__))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Created class Foo\TestHandler, in file ' . __DIR__))
-            ->shouldBeCalled();
+            ->expects(self::atLeast(4))
+            ->method('writeln')
+            ->with(self::logicalOr(
+                self::stringContains('Creating request handler Foo\TestHandler'),
+                self::stringContains('Success'),
+                self::stringContains('Created template ' . $generatedTemplate . ' in file ' . __FILE__),
+                self::stringContains('Created class Foo\TestHandler, in file ' . __DIR__)
+            ));
 
         $method = $this->reflectExecuteMethod($command);
 
         self::assertSame(0, $method->invoke(
             $command,
-            $this->input->reveal(),
-            $this->output->reveal()
+            $this->input,
+            $this->output
         ));
     }
 
@@ -285,10 +282,10 @@ class CreateHandlerCommandTest extends TestCase
             '%template-name%'      => $templateName,
         ];
 
-        $this->container->has(TemplateRendererInterface::class)->willReturn(true);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(true);
         $command = $this->createCommand();
         $this->disableRequireHandlerDirective($command);
-        $command->setApplication($this->mockApplication()->reveal());
+        $command->setApplication($this->mockApplication());
 
         $generator = Mockery::mock('overload:' . CreateHandler::class);
         $generator->shouldReceive('process')
@@ -303,41 +300,42 @@ class CreateHandlerCommandTest extends TestCase
             ->with('Foo\TestHandler', $templateNamespace, $templateName, $templateExtension)
             ->andReturn($template);
 
-        $this->input->getArgument('handler')->willReturn('Foo\TestHandler');
-        $this->input->getOption('without-template')->willReturn(false);
-        $this->input->getOption('with-template-namespace')->willReturn($templateNamespace);
-        $this->input->getOption('with-template-name')->willReturn($templateName);
-        $this->input->getOption('with-template-extension')->willReturn($templateExtension);
-        $this->input->getOption('no-factory')->willReturn(false);
-        $this->input->getOption('no-register')->willReturn(false);
+        $this->input->method('getArgument')->with('handler')->willReturn('Foo\TestHandler');
+        $this->input->method('getOption')
+            ->willReturnMap([
+                ['without-template', false],
+                ['with-template-namespace', $templateNamespace],
+                ['with-template-name', $templateName],
+                ['with-template-extension', $templateExtension],
+                ['no-factory', false],
+                ['no-register', false],
+            ]);
+
         $this->output
-            ->writeln(Argument::containingString('Creating request handler Foo\TestHandler'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Success'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Created template ' . $generatedTemplate . ' in file ' . __FILE__))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Created class Foo\TestHandler, in file ' . __DIR__))
-            ->shouldBeCalled();
+            ->expects(self::atLeast(4))
+            ->method('writeln')
+            ->with(self::logicalOr(
+                self::stringContains('Creating request handler Foo\TestHandler'),
+                self::stringContains('Success'),
+                self::stringContains('Created template ' . $generatedTemplate . ' in file ' . __FILE__),
+                self::stringContains('Created class Foo\TestHandler, in file ' . __DIR__)
+            ));
 
         $method = $this->reflectExecuteMethod($command);
 
         self::assertSame(0, $method->invoke(
             $command,
-            $this->input->reveal(),
-            $this->output->reveal()
+            $this->input,
+            $this->output
         ));
     }
 
     public function testCommandWillNotGenerateTemplateWithProvidedOptionsWhenWithoutTemplateOptionProvided(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(true);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(true);
         $command = $this->createCommand();
         $this->disableRequireHandlerDirective($command);
-        $command->setApplication($this->mockApplication()->reveal());
+        $command->setApplication($this->mockApplication());
 
         $generator = Mockery::mock('overload:' . CreateHandler::class);
         $generator->shouldReceive('process')
@@ -345,40 +343,40 @@ class CreateHandlerCommandTest extends TestCase
             ->with('Foo\TestHandler', [])
             ->andReturn(__DIR__);
 
-        $this->input->getArgument('handler')->willReturn('Foo\TestHandler');
-        $this->input->getOption('without-template')->willReturn(true);
-        $this->input->getOption('with-template-namespace')->shouldNotBeCalled();
-        $this->input->getOption('with-template-name')->shouldNotBeCalled();
-        $this->input->getOption('with-template-extension')->shouldNotBeCalled();
-        $this->input->getOption('no-factory')->willReturn(false);
-        $this->input->getOption('no-register')->willReturn(false);
+        $this->input->method('getArgument')->with('handler')->willReturn('Foo\TestHandler');
+        $this->input->method('getOption')
+            ->willReturnMap([
+                ['without-template', true],
+                ['no-factory', false],
+                ['no-register', false],
+            ]);
+
         $this->output
-            ->writeln(Argument::containingString('Creating request handler Foo\TestHandler'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Success'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Created template'))
-            ->shouldNotBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Created class Foo\TestHandler, in file ' . __DIR__))
-            ->shouldBeCalled();
+            ->expects(self::atLeast(3))
+            ->method('writeln')
+            ->with(self::logicalAnd(
+                self::logicalOr(
+                    self::stringContains('Creating request handler Foo\TestHandler'),
+                    self::stringContains('Success'),
+                    self::stringContains('Created class Foo\TestHandler, in file ' . __DIR__)
+                ),
+                self::logicalNot(self::stringContains('Created template')),
+            ));
 
         $method = $this->reflectExecuteMethod($command);
 
         self::assertSame(0, $method->invoke(
             $command,
-            $this->input->reveal(),
-            $this->output->reveal()
+            $this->input,
+            $this->output
         ));
     }
 
     public function testAllowsExceptionsRaisedFromCreateHandlerToBubbleUp(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(false);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(false);
         $command = $this->createCommand();
-        $command->setApplication($this->mockApplication()->reveal());
+        $command->setApplication($this->mockApplication());
 
         $generator = Mockery::mock('overload:' . CreateHandler::class);
         $generator->shouldReceive('process')
@@ -386,14 +384,14 @@ class CreateHandlerCommandTest extends TestCase
             ->with('Foo\TestHandler', [])
             ->andThrow(CreateHandlerException::class, 'ERROR THROWN');
 
-        $this->input->getArgument('handler')->willReturn('Foo\TestHandler');
+        $this->input->method('getArgument')->with('handler')->willReturn('Foo\TestHandler');
         $this->output
-            ->writeln(Argument::containingString('Creating request handler Foo\TestHandler'))
-            ->shouldBeCalled();
-
-        $this->output
-            ->writeln(Argument::containingString('Success'))
-            ->shouldNotBeCalled();
+            ->expects(self::atLeast(1))
+            ->method('writeln')
+            ->with(self::logicalAnd(
+                self::stringContains('Creating request handler Foo\TestHandler'),
+                self::logicalNot(self::stringContains('Success')),
+            ));
 
         $method = $this->reflectExecuteMethod($command);
 
@@ -402,17 +400,17 @@ class CreateHandlerCommandTest extends TestCase
 
         $method->invoke(
             $command,
-            $this->input->reveal(),
-            $this->output->reveal()
+            $this->input,
+            $this->output
         );
     }
 
     public function testAllowsExceptionsRaisedFromCreateHandlerToBubbleUpWhenRendererIsRegistered(): void
     {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(true);
+        $this->container->method('has')->with(TemplateRendererInterface::class)->willReturn(true);
         $command = $this->createCommand();
         $this->disableRequireHandlerDirective($command);
-        $command->setApplication($this->mockApplication()->reveal());
+        $command->setApplication($this->mockApplication());
 
         $generator = Mockery::mock('overload:' . CreateHandler::class);
         $generator->shouldReceive('process')
@@ -423,18 +421,21 @@ class CreateHandlerCommandTest extends TestCase
             ])
             ->andThrow(CreateHandlerException::class, 'ERROR THROWN');
 
-        $this->input->getArgument('handler')->willReturn('InvalidTestHandler');
-        $this->input->getOption('without-template')->willReturn(false);
-        $this->input->getOption('with-template-namespace')->willReturn(null);
-        $this->input->getOption('with-template-name')->willReturn(null);
-        $this->input->getOption('with-template-extension')->willReturn(null);
-        $this->output
-            ->writeln(Argument::containingString('Creating request handler InvalidTestHandler'))
-            ->shouldBeCalled();
+        $this->input->method('getArgument')->with('handler')->willReturn('InvalidTestHandler');
+        $this->input->method('getOption')->willReturnMap([
+            ['without-template', false],
+            ['with-template-namespace', null],
+            ['with-template-name', null],
+            ['with-template-extension', null],
+        ]);
 
         $this->output
-            ->writeln(Argument::containingString('Success'))
-            ->shouldNotBeCalled();
+            ->expects(self::atLeast(1))
+            ->method('writeln')
+            ->with(self::logicalAnd(
+                self::stringContains('Creating request handler InvalidTestHandler'),
+                self::logicalNot(self::stringContains('Success')),
+            ));
 
         $method = $this->reflectExecuteMethod($command);
 
@@ -443,8 +444,8 @@ class CreateHandlerCommandTest extends TestCase
 
         $method->invoke(
             $command,
-            $this->input->reveal(),
-            $this->output->reveal()
+            $this->input,
+            $this->output
         );
     }
 }

--- a/test/CreateMiddleware/CreateMiddlewareCommandTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareCommandTest.php
@@ -36,7 +36,7 @@ class CreateMiddlewareCommandTest extends TestCase
     private ObjectProphecy $input;
 
     /** @var ObjectProphecy<ConsoleOutputInterface> */
-    private $output;
+    private ObjectProphecy $output;
 
     private CreateMiddlewareCommand $command;
 
@@ -63,14 +63,14 @@ class CreateMiddlewareCommandTest extends TestCase
     /**
      * @return ObjectProphecy<Application>
      */
-    private function mockApplication()
+    private function mockApplication(): ObjectProphecy
     {
         $helperSet = $this->prophesize(HelperSet::class)->reveal();
 
         $factoryCommand = $this->prophesize(Command::class);
         $factoryCommand
             ->run(
-                Argument::that(static function ($input) {
+                Argument::that(static function ($input): ArrayInput {
                     Assert::assertInstanceOf(ArrayInput::class, $input);
                     Assert::assertStringContainsString('mezzio:factory:create', (string) $input);
                     Assert::assertStringContainsString('Foo\TestMiddleware', (string) $input);

--- a/test/CreateMiddleware/CreateMiddlewareCommandTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareCommandTest.php
@@ -33,7 +33,7 @@ class CreateMiddlewareCommandTest extends TestCase
     use ProphecyTrait;
 
     /** @var ObjectProphecy<InputInterface> */
-    private $input;
+    private ObjectProphecy $input;
 
     /** @var ObjectProphecy<ConsoleOutputInterface> */
     private $output;
@@ -70,7 +70,7 @@ class CreateMiddlewareCommandTest extends TestCase
         $factoryCommand = $this->prophesize(Command::class);
         $factoryCommand
             ->run(
-                Argument::that(function ($input) {
+                Argument::that(static function ($input) {
                     Assert::assertInstanceOf(ArrayInput::class, $input);
                     Assert::assertStringContainsString('mezzio:factory:create', (string) $input);
                     Assert::assertStringContainsString('Foo\TestMiddleware', (string) $input);
@@ -82,7 +82,7 @@ class CreateMiddlewareCommandTest extends TestCase
 
         $application = $this->prophesize(Application::class);
         $application->getHelperSet()->willReturn($helperSet);
-        $application->find('mezzio:factory:create')->will([$factoryCommand, 'reveal']);
+        $application->find('mezzio:factory:create')->will(static fn(): object => $factoryCommand->reveal());
 
         return $application;
     }

--- a/test/Factory/CreateFactoryCommandTest.php
+++ b/test/Factory/CreateFactoryCommandTest.php
@@ -32,7 +32,7 @@ class CreateFactoryCommandTest extends TestCase
     private ObjectProphecy $input;
 
     /** @var ObjectProphecy<ConsoleOutputInterface> */
-    private $output;
+    private ObjectProphecy $output;
 
     private CreateFactoryCommand $command;
 

--- a/test/Factory/CreateFactoryCommandTest.php
+++ b/test/Factory/CreateFactoryCommandTest.php
@@ -29,7 +29,7 @@ class CreateFactoryCommandTest extends TestCase
     use ProphecyTrait;
 
     /** @var ObjectProphecy<InputInterface> */
-    private $input;
+    private ObjectProphecy $input;
 
     /** @var ObjectProphecy<ConsoleOutputInterface> */
     private $output;

--- a/test/Factory/CreateFactoryCommandTest.php
+++ b/test/Factory/CreateFactoryCommandTest.php
@@ -11,10 +11,8 @@ use Mezzio\Tooling\Factory\CreateFactoryCommand;
 use Mezzio\Tooling\Factory\FactoryClassGenerator;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -26,20 +24,19 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 class CreateFactoryCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
-    use ProphecyTrait;
 
-    /** @var ObjectProphecy<InputInterface> */
-    private ObjectProphecy $input;
+    /** @var InputInterface&MockObject */
+    private InputInterface $input;
 
-    /** @var ObjectProphecy<ConsoleOutputInterface> */
-    private ObjectProphecy $output;
+    /** @var ConsoleOutputInterface&MockObject */
+    private ConsoleOutputInterface $output;
 
     private CreateFactoryCommand $command;
 
     protected function setUp(): void
     {
-        $this->input  = $this->prophesize(InputInterface::class);
-        $this->output = $this->prophesize(ConsoleOutputInterface::class);
+        $this->input  = $this->createMock(InputInterface::class);
+        $this->output = $this->createMock(ConsoleOutputInterface::class);
 
         $this->command = new CreateFactoryCommand(
             new Create(new FactoryClassGenerator()),
@@ -83,8 +80,12 @@ class CreateFactoryCommandTest extends TestCase
 
     public function testSuccessfulExecutionEmitsExpectedMessages(): void
     {
-        $generator = $this->prophesize(Create::class);
-        $generator->createForClass('Foo\TestHandler')->willReturn(__DIR__)->shouldBeCalled();
+        $generator = $this->createMock(Create::class);
+        $generator
+            ->expects(self::atLeastOnce())
+            ->method('createForClass')
+            ->with('Foo\TestHandler')
+            ->willReturn(__DIR__);
 
         $injector = Mockery::mock('overload:' . ConfigInjector::class);
         $injector->shouldReceive('injectFactoryForClass')
@@ -92,51 +93,51 @@ class CreateFactoryCommandTest extends TestCase
             ->with('Foo\TestHandlerFactory', 'Foo\TestHandler')
             ->andReturn('some-file-name');
 
-        $this->input->getArgument('class')->willReturn('Foo\TestHandler');
-        $this->input->getOption('no-register')->willReturn(false);
-        $this->output
-            ->writeln(Argument::containingString('Creating factory for class Foo\TestHandler'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Registering factory with container'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Success'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Created factory class Foo\TestHandlerFactory, in file ' . __DIR__))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Registered factory to container'))
-            ->shouldBeCalled();
+        $this->input->method('getArgument')->with('class')->willReturn('Foo\TestHandler');
+        $this->input->method('getOption')->with('no-register')->willReturn(false);
 
-        $command = new CreateFactoryCommand($generator->reveal(), '');
+        $this->output
+            ->expects(self::atLeast(5))
+            ->method('writeln')
+            ->with(self::logicalOr(
+                self::stringContains('Creating factory for class Foo\TestHandler'),
+                self::stringContains('Registering factory with container'),
+                self::stringContains('Success'),
+                self::stringContains('Created factory class Foo\TestHandlerFactory, in file ' . __DIR__),
+                self::stringContains('Registered factory to container'),
+            ));
+
+        $command = new CreateFactoryCommand($generator, '');
 
         $method = $this->reflectExecuteMethod($command);
 
         self::assertSame(0, $method->invoke(
             $command,
-            $this->input->reveal(),
-            $this->output->reveal()
+            $this->input,
+            $this->output
         ));
     }
 
     public function testAllowsExceptionsRaisedFromCreateToBubbleUp(): void
     {
-        $generator = $this->prophesize(Create::class);
-        $generator->createForClass('Foo\TestHandler')->willThrow(ClassNotFoundException::class)->shouldBeCalled();
+        $generator = $this->createMock(Create::class);
+        $generator->expects(self::atLeastOnce())
+            ->method('createForClass')
+            ->with('Foo\TestHandler')
+            ->willThrowException(new ClassNotFoundException());
 
-        $this->input->getArgument('class')->willReturn('Foo\TestHandler');
-        $this->input->getOption('no-register')->willReturn(false);
+        $this->input->method('getArgument')->with('class')->willReturn('Foo\TestHandler');
+        $this->input->method('getOption')->with('no-register')->willReturn(false);
+
         $this->output
-            ->writeln(Argument::containingString('Creating factory for class Foo\TestHandler'))
-            ->shouldBeCalled();
+            ->expects(self::atLeastOnce())
+            ->method('writeln')
+            ->with(self::logicalAnd(
+                self::stringContains('Creating factory for class Foo\TestHandler'),
+                self::logicalNot(self::stringContains('Success')),
+            ));
 
-        $this->output
-            ->writeln(Argument::containingString('Success'))
-            ->shouldNotBeCalled();
-
-        $command = new CreateFactoryCommand($generator->reveal(), '');
+        $command = new CreateFactoryCommand($generator, '');
 
         $method = $this->reflectExecuteMethod($command);
 
@@ -144,8 +145,8 @@ class CreateFactoryCommandTest extends TestCase
 
         $method->invoke(
             $command,
-            $this->input->reveal(),
-            $this->output->reveal()
+            $this->input,
+            $this->output
         );
     }
 }

--- a/test/Factory/CreateTest.php
+++ b/test/Factory/CreateTest.php
@@ -11,7 +11,6 @@ use Mezzio\Tooling\Factory\FactoryWriteException;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use TestHarness\NotReal\TestClass;
 
@@ -19,8 +18,6 @@ use function file_put_contents;
 
 class CreateTest extends TestCase
 {
-    use ProphecyTrait;
-
     private vfsStreamDirectory $dir;
 
     private Create $factory;
@@ -57,10 +54,10 @@ class CreateTest extends TestCase
         $this->dir->chmod(0544);
         $className = TestClass::class;
 
-        $generator = $this->prophesize(FactoryClassGenerator::class);
-        $generator->createFactory($className)->willReturn('not-generated');
+        $generator = $this->createMock(FactoryClassGenerator::class);
+        $generator->method('createFactory')->with($className)->willReturn('not-generated');
 
-        $factory = new Create($generator->reveal());
+        $factory = new Create($generator);
 
         $this->expectException(FactoryWriteException::class);
         $factory->createForClass($className);
@@ -85,9 +82,9 @@ class CreateTest extends TestCase
         $factoryName = $className . 'Factory';
         $factory     = new $factoryName();
 
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->get(FactoryClassGenerator::class)->willReturn($generator);
-        $instance = $factory($container->reveal());
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with(FactoryClassGenerator::class)->willReturn($generator);
+        $instance = $factory($container);
         self::assertInstanceOf($className, $instance);
     }
 }

--- a/test/Factory/CreateTest.php
+++ b/test/Factory/CreateTest.php
@@ -13,6 +13,7 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
+use TestHarness\NotReal\TestClass;
 
 use function file_put_contents;
 
@@ -40,7 +41,7 @@ class CreateTest extends TestCase
     public function testRaisesExceptionWhenFactoryClassFileAlreadyExists(): void
     {
         require $this->projectRoot . '/TestClass.php';
-        $className = 'TestHarness\NotReal\TestClass';
+        $className = TestClass::class;
         file_put_contents($this->projectRoot . '/TestClassFactory.php', '');
 
         $this->expectException(FactoryAlreadyExistsException::class);
@@ -54,7 +55,7 @@ class CreateTest extends TestCase
     {
         require $this->projectRoot . '/TestClass.php';
         $this->dir->chmod(0544);
-        $className = 'TestHarness\NotReal\TestClass';
+        $className = TestClass::class;
 
         $generator = $this->prophesize(FactoryClassGenerator::class);
         $generator->createFactory($className)->willReturn('not-generated');
@@ -71,7 +72,7 @@ class CreateTest extends TestCase
     public function testCanCreateFactoryFile(): void
     {
         require $this->projectRoot . '/TestClass.php';
-        $className = 'TestHarness\NotReal\TestClass';
+        $className = TestClass::class;
 
         $generator = new FactoryClassGenerator();
         $factory   = new Create($generator);

--- a/test/Factory/FactoryClassGeneratorTest.php
+++ b/test/Factory/FactoryClassGeneratorTest.php
@@ -9,6 +9,7 @@ use MezzioTest\Tooling\Factory\TestAsset\ComplexDependencyObject;
 use MezzioTest\Tooling\Factory\TestAsset\InvokableObject;
 use MezzioTest\Tooling\Factory\TestAsset\SimpleDependencyObject;
 use PHPUnit\Framework\TestCase;
+use This\Duplicates\ClassDuplicatingNamespaceNameCase\ClassDuplicatingNamespaceName;
 
 use function file_get_contents;
 
@@ -51,7 +52,7 @@ class FactoryClassGeneratorTest extends TestCase
     public function testCreateFactoryCreatesAppropriatelyNamedFactoryWhenClassNameAppearsWithinNamespace(): void
     {
         require __DIR__ . '/TestAsset/classes/ClassDuplicatingNamespaceName.php';
-        $className = 'This\Duplicates\ClassDuplicatingNamespaceNameCase\ClassDuplicatingNamespaceName';
+        $className = ClassDuplicatingNamespaceName::class;
         $factory   = file_get_contents(__DIR__ . '/TestAsset/factories/ClassDuplicatingNamespaceName.php');
 
         self::assertEquals($factory, $this->generator->createFactory($className));

--- a/test/MigrateInteropMiddleware/ConvertInteropMiddlewareTest.php
+++ b/test/MigrateInteropMiddleware/ConvertInteropMiddlewareTest.php
@@ -20,7 +20,7 @@ class ConvertInteropMiddlewareTest extends TestCase
 
         $console = $this->setupConsoleHelper();
 
-        $converter = new ConvertInteropMiddleware($console->reveal());
+        $converter = new ConvertInteropMiddleware($console);
         $converter->process($path);
 
         self::assertExpected($path);

--- a/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
+++ b/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
@@ -34,7 +34,7 @@ class MigrateInteropMiddlewareCommandTest extends TestCase
     private ObjectProphecy $input;
 
     /** @var ObjectProphecy<ConsoleOutputInterface> */
-    private $output;
+    private ObjectProphecy $output;
 
     private MigrateInteropMiddlewareCommand $command;
 

--- a/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
+++ b/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
@@ -10,10 +10,8 @@ use Mezzio\Tooling\MigrateInteropMiddleware\MigrateInteropMiddlewareCommand;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionClass;
 use ReflectionMethod;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,20 +26,19 @@ use function mkdir;
 class MigrateInteropMiddlewareCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
-    use ProphecyTrait;
 
-    /** @var ObjectProphecy<InputInterface> */
-    private ObjectProphecy $input;
+    /** @var InputInterface&MockObject */
+    private InputInterface $input;
 
-    /** @var ObjectProphecy<ConsoleOutputInterface> */
-    private ObjectProphecy $output;
+    /** @var ConsoleOutputInterface&MockObject */
+    private ConsoleOutputInterface $output;
 
     private MigrateInteropMiddlewareCommand $command;
 
     protected function setUp(): void
     {
-        $this->input  = $this->prophesize(InputInterface::class);
-        $this->output = $this->prophesize(ConsoleOutputInterface::class);
+        $this->input  = $this->createMock(InputInterface::class);
+        $this->output = $this->createMock(ConsoleOutputInterface::class);
 
         $this->command = new MigrateInteropMiddlewareCommand('');
     }
@@ -96,22 +93,23 @@ class MigrateInteropMiddlewareCommandTest extends TestCase
             ->with($path . '/src')
             ->andReturnNull();
 
-        $this->input->getOption('src')->willReturn('src');
+        $this->input->method('getOption')->with('src')->willReturn('src');
 
         $this->output
-            ->writeln(Argument::containingString('Scanning for usage of http-interop middleware...'))
-            ->shouldBeCalled();
-        $this->output
-            ->writeln(Argument::containingString('Done!'))
-            ->shouldBeCalled();
+            ->expects(self::atLeast(2))
+            ->method('writeln')
+            ->with(self::logicalOr(
+                self::stringContains('Scanning for usage of http-interop middleware...'),
+                self::stringContains('Done!'),
+            ));
 
         $command = new MigrateInteropMiddlewareCommand($path);
         $method  = $this->reflectExecuteMethod($command);
 
         self::assertSame(0, $method->invoke(
             $command,
-            $this->input->reveal(),
-            $this->output->reveal()
+            $this->input,
+            $this->output
         ));
     }
 
@@ -123,7 +121,7 @@ class MigrateInteropMiddlewareCommandTest extends TestCase
         $converter = Mockery::mock('overload:' . ConvertInteropMiddleware::class);
         $converter->shouldNotReceive('process');
 
-        $this->input->getOption('src')->willReturn('src');
+        $this->input->method('getOption')->with('src')->willReturn('src');
 
         $command = new MigrateInteropMiddlewareCommand($path);
         $method  = $this->reflectExecuteMethod($command);
@@ -133,8 +131,8 @@ class MigrateInteropMiddlewareCommandTest extends TestCase
 
         $method->invoke(
             $command,
-            $this->input->reveal(),
-            $this->output->reveal()
+            $this->input,
+            $this->output
         );
     }
 }

--- a/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
+++ b/test/MigrateInteropMiddleware/MigrateInteropMiddlewareCommandTest.php
@@ -31,7 +31,7 @@ class MigrateInteropMiddlewareCommandTest extends TestCase
     use ProphecyTrait;
 
     /** @var ObjectProphecy<InputInterface> */
-    private $input;
+    private ObjectProphecy $input;
 
     /** @var ObjectProphecy<ConsoleOutputInterface> */
     private $output;
@@ -61,9 +61,10 @@ class MigrateInteropMiddlewareCommandTest extends TestCase
         );
     }
 
-    /** @return scalar */
-    private function getConstantValue(string $const, string $class = MigrateInteropMiddlewareCommand::class)
-    {
+    private function getConstantValue(
+        string $const,
+        string $class = MigrateInteropMiddlewareCommand::class
+    ): bool|string|int|float {
         $r = new ReflectionClass($class);
 
         return $r->getConstant($const);

--- a/test/MigrateInteropMiddleware/ProjectSetupTrait.php
+++ b/test/MigrateInteropMiddleware/ProjectSetupTrait.php
@@ -50,12 +50,15 @@ trait ProjectSetupTrait
         if (! $file->isFile()) {
             return false;
         }
+
         if ($file->getExtension() !== 'php') {
             return false;
         }
+
         if (! $file->isReadable()) {
             return false;
         }
+
         return $file->isWritable();
     }
 

--- a/test/MigrateInteropMiddleware/ProjectSetupTrait.php
+++ b/test/MigrateInteropMiddleware/ProjectSetupTrait.php
@@ -7,9 +7,7 @@ namespace MezzioTest\Tooling\MigrateInteropMiddleware;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\Assert;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework\MockObject\MockObject;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
@@ -23,8 +21,6 @@ use const DIRECTORY_SEPARATOR;
 
 trait ProjectSetupTrait
 {
-    use ProphecyTrait;
-
     private function setupSrcDir(string|vfsStreamDirectory $dir): void
     {
         $base = realpath(__DIR__ . '/TestAsset') . DIRECTORY_SEPARATOR;
@@ -62,31 +58,22 @@ trait ProjectSetupTrait
         return $file->isWritable();
     }
 
-    /**
-     * @return ObjectProphecy<OutputInterface>
-     */
-    private function setupConsoleHelper()
+    /** @return OutputInterface&MockObject */
+    private function setupConsoleHelper(): OutputInterface
     {
-        $console = $this->prophesize(OutputInterface::class);
+        $console = $this->createMock(OutputInterface::class);
 
         $console
-            ->writeln(Argument::containingString('src/InteropAliasMiddleware.php'))
-            ->shouldBeCalled();
-        $console
-            ->writeln(Argument::containingString('src/MultilineMiddleware.php'))
-            ->shouldBeCalled();
-        $console
-            ->writeln(Argument::containingString('src/MultipleInterfacesMiddleware.php'))
-            ->shouldBeCalled();
-        $console
-            ->writeln(Argument::containingString('src/MyClass.php'))
-            ->shouldBeCalled();
-        $console
-            ->writeln(Argument::containingString('src/MyInteropDelegate.php'))
-            ->shouldBeCalled();
-        $console
-            ->writeln(Argument::containingString('src/MyInteropMiddleware.php'))
-            ->shouldBeCalled();
+            ->expects(self::atLeast(6))
+            ->method('writeln')
+            ->with(self::logicalOr(
+                self::stringContains('src/InteropAliasMiddleware.php'),
+                self::stringContains('src/MultilineMiddleware.php'),
+                self::stringContains('src/MultipleInterfacesMiddleware.php'),
+                self::stringContains('src/MyClass.php'),
+                self::stringContains('src/MyInteropDelegate.php'),
+                self::stringContains('src/MyInteropMiddleware.php'),
+            ));
 
         return $console;
     }

--- a/test/MigrateInteropMiddleware/ProjectSetupTrait.php
+++ b/test/MigrateInteropMiddleware/ProjectSetupTrait.php
@@ -25,8 +25,7 @@ trait ProjectSetupTrait
 {
     use ProphecyTrait;
 
-    /** @param string|vfsStreamDirectory $dir */
-    private function setupSrcDir($dir): void
+    private function setupSrcDir(string|vfsStreamDirectory $dir): void
     {
         $base = realpath(__DIR__ . '/TestAsset') . DIRECTORY_SEPARATOR;
         $rdi  = new RecursiveDirectoryIterator($base . 'src');
@@ -48,10 +47,16 @@ trait ProjectSetupTrait
 
     private static function isPhpFile(SplFileInfo $file): bool
     {
-        return $file->isFile()
-            && $file->getExtension() === 'php'
-            && $file->isReadable()
-            && $file->isWritable();
+        if (! $file->isFile()) {
+            return false;
+        }
+        if ($file->getExtension() !== 'php') {
+            return false;
+        }
+        if (! $file->isReadable()) {
+            return false;
+        }
+        return $file->isWritable();
     }
 
     /**

--- a/test/MigrateMiddlewareToRequestHandler/ConvertMiddlewareTest.php
+++ b/test/MigrateMiddlewareToRequestHandler/ConvertMiddlewareTest.php
@@ -20,7 +20,7 @@ class ConvertMiddlewareTest extends TestCase
 
         $console = $this->setupConsoleHelper();
 
-        $converter = new ConvertMiddleware($console->reveal());
+        $converter = new ConvertMiddleware($console);
         $converter->process($path);
 
         self::assertExpected($path);

--- a/test/MigrateMiddlewareToRequestHandler/MigrateMiddlewareToRequestHandlerCommandTest.php
+++ b/test/MigrateMiddlewareToRequestHandler/MigrateMiddlewareToRequestHandlerCommandTest.php
@@ -35,7 +35,7 @@ class MigrateMiddlewareToRequestHandlerCommandTest extends TestCase
     private ObjectProphecy $input;
 
     /** @var ObjectProphecy<ConsoleOutputInterface> */
-    private $output;
+    private ObjectProphecy $output;
 
     private MigrateMiddlewareToRequestHandlerCommand $command;
 
@@ -101,9 +101,7 @@ class MigrateMiddlewareToRequestHandlerCommandTest extends TestCase
         $this->input->getOption('src')->willReturn('src');
 
         $this->output
-            ->writeln(Argument::that(
-                static fn($arg) => preg_match('#Scanning "[^"]+" for PSR-15 middleware to convert#', $arg)
-            ))
+            ->writeln(Argument::that(static fn($arg): int|false => preg_match('#Scanning "[^"]+" for PSR-15 middleware to convert#', $arg)))
             ->shouldBeCalledTimes(1);
         $this->output
             ->writeln(Argument::containingString('Done!'))

--- a/test/MigrateMiddlewareToRequestHandler/MigrateMiddlewareToRequestHandlerCommandTest.php
+++ b/test/MigrateMiddlewareToRequestHandler/MigrateMiddlewareToRequestHandlerCommandTest.php
@@ -32,7 +32,7 @@ class MigrateMiddlewareToRequestHandlerCommandTest extends TestCase
     use ProphecyTrait;
 
     /** @var ObjectProphecy<InputInterface> */
-    private $input;
+    private ObjectProphecy $input;
 
     /** @var ObjectProphecy<ConsoleOutputInterface> */
     private $output;

--- a/test/MigrateMiddlewareToRequestHandler/ProjectSetupTrait.php
+++ b/test/MigrateMiddlewareToRequestHandler/ProjectSetupTrait.php
@@ -26,8 +26,7 @@ trait ProjectSetupTrait
 {
     use ProphecyTrait;
 
-    /** @param string|vfsStreamDirectory $dir */
-    private function setupSrcDir($dir): void
+    private function setupSrcDir(string|vfsStreamDirectory $dir): void
     {
         $base = realpath(__DIR__ . '/TestAsset') . DIRECTORY_SEPARATOR;
         $rdi  = new RecursiveDirectoryIterator($base . 'src');
@@ -49,10 +48,16 @@ trait ProjectSetupTrait
 
     private static function isPhpFile(SplFileInfo $file): bool
     {
-        return $file->isFile()
-            && $file->getExtension() === 'php'
-            && $file->isReadable()
-            && $file->isWritable();
+        if (! $file->isFile()) {
+            return false;
+        }
+        if ($file->getExtension() !== 'php') {
+            return false;
+        }
+        if (! $file->isReadable()) {
+            return false;
+        }
+        return $file->isWritable();
     }
 
     /**

--- a/test/MigrateMiddlewareToRequestHandler/ProjectSetupTrait.php
+++ b/test/MigrateMiddlewareToRequestHandler/ProjectSetupTrait.php
@@ -51,12 +51,15 @@ trait ProjectSetupTrait
         if (! $file->isFile()) {
             return false;
         }
+
         if ($file->getExtension() !== 'php') {
             return false;
         }
+
         if (! $file->isReadable()) {
             return false;
         }
+
         return $file->isWritable();
     }
 
@@ -69,27 +72,27 @@ trait ProjectSetupTrait
 
         $console
             ->writeln(Argument::that(
-                static fn($arg) => preg_match('#Updating .*src/MultilineMiddleware\.php#', $arg) !== false
+                static fn($arg): bool => preg_match('#Updating .*src/MultilineMiddleware\.php#', $arg) !== false
             ))
             ->shouldBeCalled();
         $console
             ->writeln(Argument::that(
-                static fn($arg) => preg_match('#Updating .*src/MultipleInterfacesMiddleware\.php#', $arg) !== false
+                static fn($arg): bool => preg_match('#Updating .*src/MultipleInterfacesMiddleware\.php#', $arg) !== false
             ))
             ->shouldBeCalled();
         $console
             ->writeln(Argument::that(
-                static fn($arg) => preg_match('#Updating .*src/MyActionWithAliases\.php#', $arg) !== false
+                static fn($arg): bool => preg_match('#Updating .*src/MyActionWithAliases\.php#', $arg) !== false
             ))
             ->shouldBeCalled();
         $console
             ->writeln(Argument::that(
-                static fn($arg) => preg_match('#Updating .*src/MyMiddleware\.php#', $arg) !== false
+                static fn($arg): bool => preg_match('#Updating .*src/MyMiddleware\.php#', $arg) !== false
             ))
             ->shouldBeCalled();
         $console
             ->writeln(Argument::that(
-                static fn($arg) => preg_match('#Skipping .*src/MyMiddlewareWithHandler\.php#', $arg) !== false
+                static fn($arg): bool => preg_match('#Skipping .*src/MyMiddlewareWithHandler\.php#', $arg) !== false
             ))
             ->shouldBeCalled();
 

--- a/test/Module/CommandCommonOptionsTest.php
+++ b/test/Module/CommandCommonOptionsTest.php
@@ -15,7 +15,7 @@ class CommandCommonOptionsTest extends TestCase
     use ProphecyTrait;
 
     /** @var ObjectProphecy<InputInterface> */
-    private $input;
+    private ObjectProphecy $input;
 
     protected function setUp(): void
     {
@@ -24,6 +24,7 @@ class CommandCommonOptionsTest extends TestCase
 
     public function testGetModulesPathGetsOptionsFromInput(): void
     {
+        $config = [];
         $this->input->getOption('modules-path')->willReturn('path-from-input');
         $config[CommandCommonOptions::class]['--modules-path'] = 'path-from-config';
 
@@ -35,6 +36,7 @@ class CommandCommonOptionsTest extends TestCase
 
     public function testGetModulesPathGetsOptionsFromConfig(): void
     {
+        $config = [];
         $this->input->getOption('modules-path')->willReturn(null);
         $config[CommandCommonOptions::class]['--modules-path'] = 'path-from-config';
 

--- a/test/Module/CommandCommonOptionsTest.php
+++ b/test/Module/CommandCommonOptionsTest.php
@@ -5,54 +5,51 @@ declare(strict_types=1);
 namespace MezzioTest\Tooling\Module;
 
 use Mezzio\Tooling\Module\CommandCommonOptions;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Input\InputInterface;
 
 class CommandCommonOptionsTest extends TestCase
 {
-    use ProphecyTrait;
-
-    /** @var ObjectProphecy<InputInterface> */
-    private ObjectProphecy $input;
+    /** @var InputInterface&MockObject */
+    private InputInterface $input;
 
     protected function setUp(): void
     {
-        $this->input = $this->prophesize(InputInterface::class);
+        $this->input = $this->createMock(InputInterface::class);
     }
 
     public function testGetModulesPathGetsOptionsFromInput(): void
     {
         $config = [];
-        $this->input->getOption('modules-path')->willReturn('path-from-input');
+        $this->input->method('getOption')->with('modules-path')->willReturn('path-from-input');
         $config[CommandCommonOptions::class]['--modules-path'] = 'path-from-config';
 
         self::assertEquals(
             'path-from-input',
-            CommandCommonOptions::getModulesPath($this->input->reveal(), $config)
+            CommandCommonOptions::getModulesPath($this->input, $config)
         );
     }
 
     public function testGetModulesPathGetsOptionsFromConfig(): void
     {
         $config = [];
-        $this->input->getOption('modules-path')->willReturn(null);
+        $this->input->method('getOption')->with('modules-path')->willReturn(null);
         $config[CommandCommonOptions::class]['--modules-path'] = 'path-from-config';
 
         self::assertEquals(
             'path-from-config',
-            CommandCommonOptions::getModulesPath($this->input->reveal(), $config)
+            CommandCommonOptions::getModulesPath($this->input, $config)
         );
     }
 
     public function testGetModulesPathGetsDefaultOption(): void
     {
-        $this->input->getOption('modules-path')->willReturn(null);
+        $this->input->method('getOption')->with('modules-path')->willReturn(null);
 
         self::assertEquals(
             'src',
-            CommandCommonOptions::getModulesPath($this->input->reveal())
+            CommandCommonOptions::getModulesPath($this->input)
         );
     }
 }

--- a/test/Module/CreateCommandTest.php
+++ b/test/Module/CreateCommandTest.php
@@ -41,7 +41,7 @@ class CreateCommandTest extends TestCase
     use ProphecyTrait;
 
     /** @var ObjectProphecy<InputInterface> */
-    private $input;
+    private ObjectProphecy $input;
 
     /** @var ObjectProphecy<ConsoleOutputInterface> */
     private $output;
@@ -68,14 +68,13 @@ class CreateCommandTest extends TestCase
         $this->expectedModuleArgumentDescription = CreateCommand::HELP_ARG_MODULE;
     }
 
-    /** @return array|ArrayObject */
-    public function createConfig(bool $configAsArrayObject = false)
+    public function createConfig(bool $configAsArrayObject = false): array|ArrayObject
     {
         $configFile = $this->projectRoot . '/config/config.php';
         $config     = include $configFile;
 
         if ($configAsArrayObject) {
-            $config = new ArrayObject($config);
+            return new ArrayObject($config);
         }
 
         return $config;
@@ -109,25 +108,20 @@ class CreateCommandTest extends TestCase
         $register = $this->prophesize(Command::class);
         $register
             ->run(
-                Argument::that(function ($input) use ($name, $module, $composer, $modulePath) {
+                Argument::that(static function ($input) use ($name, $module, $composer, $modulePath) {
                     TestCase::assertInstanceOf(ArrayInput::class, $input);
-
                     $r = new ReflectionProperty($input, 'parameters');
                     $r->setAccessible(true);
-                    $parameters = $r->getValue($input);
 
+                    $parameters = $r->getValue($input);
                     TestCase::assertArrayHasKey('command', $parameters);
                     TestCase::assertEquals($name, $parameters['command']);
-
                     TestCase::assertArrayHasKey('module', $parameters);
                     TestCase::assertEquals($module, $parameters['module']);
-
                     TestCase::assertArrayHasKey('--composer', $parameters);
                     TestCase::assertEquals($composer, $parameters['--composer']);
-
                     TestCase::assertArrayHasKey('--exact-path', $parameters);
                     TestCase::assertEquals($modulePath, $parameters['--exact-path']);
-
                     return true;
                 }),
                 $output
@@ -138,8 +132,8 @@ class CreateCommandTest extends TestCase
         $helperSet = $this->prophesize(HelperSet::class);
 
         $application = $this->prophesize(Application::class);
-        $application->find($name)->will([$register, 'reveal']);
-        $application->getHelperSet()->will([$helperSet, 'reveal']);
+        $application->find($name)->will(static fn(): object => $register->reveal());
+        $application->getHelperSet()->will(static fn(): object => $helperSet->reveal());
         return $application;
     }
 

--- a/test/Module/CreateCommandTest.php
+++ b/test/Module/CreateCommandTest.php
@@ -44,17 +44,15 @@ class CreateCommandTest extends TestCase
     private ObjectProphecy $input;
 
     /** @var ObjectProphecy<ConsoleOutputInterface> */
-    private $output;
+    private ObjectProphecy $output;
 
-    /** @var CreateCommand */
-    private $command;
+    private CreateCommand $command;
 
     private vfsStreamDirectory $dir;
 
     private string $projectRoot;
 
-    /** @var string */
-    private $expectedModuleArgumentDescription;
+    private string $expectedModuleArgumentDescription;
 
     protected function setUp(): void
     {
@@ -104,11 +102,11 @@ class CreateCommandTest extends TestCase
         string $composer,
         string $modulePath,
         OutputInterface $output
-    ) {
+    ): ObjectProphecy {
         $register = $this->prophesize(Command::class);
         $register
             ->run(
-                Argument::that(static function ($input) use ($name, $module, $composer, $modulePath) {
+                Argument::that(static function ($input) use ($name, $module, $composer, $modulePath): bool {
                     TestCase::assertInstanceOf(ArrayInput::class, $input);
                     $r = new ReflectionProperty($input, 'parameters');
                     $r->setAccessible(true);

--- a/test/Module/CreateTest.php
+++ b/test/Module/CreateTest.php
@@ -109,8 +109,8 @@ class CreateTest extends TestCase
         self::assertEquals('my-modules/MyApp', $metadata->rootPath());
         self::assertFileExists($configProvider);
         $configProviderContent = file_get_contents($configProvider);
-        self::assertSame(1, preg_match('/\bnamespace MyApp\b/', $configProviderContent));
-        self::assertSame(1, preg_match('/\bclass ConfigProvider\b/', $configProviderContent));
+        self::assertSame(1, preg_match('#\bnamespace MyApp\b#', $configProviderContent));
+        self::assertSame(1, preg_match('#\bclass ConfigProvider\b#', $configProviderContent));
         $command         = $this->command;
         $expectedContent = sprintf($command::TEMPLATE_CONFIG_PROVIDER_RECOMMENDED, 'MyApp', 'my-app', '');
         self::assertSame($expectedContent, $configProviderContent);
@@ -220,8 +220,8 @@ class CreateTest extends TestCase
         self::assertEquals('my-modules/MyApp', $metadata->rootPath());
         self::assertFileExists($configProvider);
         $configProviderContent = file_get_contents($configProvider);
-        self::assertSame(1, preg_match('/\bnamespace ParentNamespace\\\\MyApp\b/', $configProviderContent));
-        self::assertSame(1, preg_match('/\bclass ConfigProvider\b/', $configProviderContent));
+        self::assertSame(1, preg_match('#\bnamespace ParentNamespace\\\MyApp\b#', $configProviderContent));
+        self::assertSame(1, preg_match('#\bclass ConfigProvider\b#', $configProviderContent));
         $command         = $this->command;
         $expectedContent = sprintf(
             $command::TEMPLATE_CONFIG_PROVIDER_RECOMMENDED,

--- a/test/TestAsset/config/container.php
+++ b/test/TestAsset/config/container.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use Prophecy\Prophet;
+use PHPUnit\Framework\MockObject\Generator;
 use Psr\Container\ContainerInterface;
 
-$prophet   = new Prophet();
-$container = $prophet->prophesize(ContainerInterface::class);
-
-return $container->reveal();
+// Note: not using an anonymous class because `psr/container` changes major version constantly,
+//       and is a pain to maintain in dependency upgrades.
+return (new Generator())
+    ->getMock(ContainerInterface::class);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

- Update composer config `platform.php` to `8.0.99`
- Update composer `PHP` to `~8.0.0 || ~8.1.0 || ~8.2.0`
- Ignore PHP platform requirements via `.laminas-ci.json`