### PR TITLE
Reduce `mockery/mockery` and Prophecy mocking dependency usages

### DIFF
--- a/src/Module/RegisterCommand.php
+++ b/src/Module/RegisterCommand.php
@@ -44,15 +44,18 @@ final class RegisterCommand extends Command
     private string $projectRoot;
 
     private ComposerProcessFactoryInterface $processFactory;
+    private InjectorInterface $injector;
 
     public function __construct(
         string $projectRoot,
         ComposerPackageFactoryInterface $packageFactory,
-        ComposerProcessFactoryInterface $processFactory
+        ComposerProcessFactoryInterface $processFactory,
+        ?InjectorInterface $configInjector = null
     ) {
         $this->projectRoot    = $projectRoot;
         $this->package        = $packageFactory->loadPackage($projectRoot);
         $this->processFactory = $processFactory;
+        $this->injector       = $configInjector ?? new ConfigAggregatorInjector($this->projectRoot);
 
         parent::__construct();
     }
@@ -81,11 +84,10 @@ final class RegisterCommand extends Command
         $modulesPath = CommandCommonOptions::getModulesPath($input);
         $exactPath   = $input->getOption('exact-path');
 
-        $injector       = new ConfigAggregatorInjector($this->projectRoot);
         $configProvider = sprintf('%s\ConfigProvider', $module);
         assert($configProvider !== '');
-        if (! $injector->isRegistered($configProvider)) {
-            $injector->inject(
+        if (! $this->injector->isRegistered($configProvider)) {
+            $this->injector->inject(
                 $configProvider,
                 InjectorInterface::TYPE_CONFIG_PROVIDER
             );

--- a/test/Module/RegisterCommandTest.php
+++ b/test/Module/RegisterCommandTest.php
@@ -90,7 +90,11 @@ class RegisterCommandTest extends TestCase
         self::assertEquals(RegisterCommand::HELP, $this->command->getHelp());
     }
 
-    /** @psalm-return array<string, array{0: bool, 1: bool, 2: bool, 3: string}> */
+    /**
+     * @psalm-return non-empty-array<
+     *     non-empty-string, array{bool, bool, bool, non-empty-string|null, non-empty-string|null}
+     * >
+     */
     public function injectedEnabled(): array
     {
         // phpcs:disable Generic.Files.LineLength.TooLong


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | yes

These are my changes from #36, extracted here.

I did a partial removal of `mockery/mockery` and `prophecy/prophecy`, which are both not really necessary in these context.

Further work needs to be done to improve the code structure of the test suite, but this PR at least contains the work done so far.