### PR TITLE
Add bin property to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,5 +82,8 @@
     },
     "conflict": {
         "zendframework/zend-expressive-tooling": "*"
-    }
+    },
+    "bin": [
+        "bin/laminas"
+    ]
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Without the change in this PR, when running _vendor/bin/mezzio-tooling_ in projects that use this package, the `mezzio` command namespace is missing when running _vendor/bin/laminas_, such as projects generated from the skeleton project. As reported in mezzio/mezzio#146, the following error is printed:

> Installed tooling package, but package does not contain script information? Check your installation, and follow the migration documentation to use the tooling.

After some experimentation, by adding this addition to the configuration, the error isn't displayed and the namespace is once again available.
