### PR TITLE
Format previous versions note as an admonition

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ This package exposes commands for [laminas-cli](https://docs.laminas.dev/laminas
 - `mezzio:module:deregister`: Deregister a middleware module from the application.
 - `mezzio:module:register`: Register a middleware module with the application.
 
-> ### Previous versions
->
+> [!NOTE]
 > Versions of mezzio/mezzio-tooling prior to v2.0 exposed a `vendor/bin/mezzio` binary, and the various commands exposed all lacked the `mezzio:` prefix, with the following more specific changes:
 >
 > - `mezzio:middleware:migrate-from-interop` was previously `migrate:interop-middleware`


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

As [GitHub-flavoured Markdown supports admonitions](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) (or what it refers to as "Alerts"), and the note being formatted is reasonably important, (to me) it makes sense to format it as an admonition/alert to bring sufficient attention to it, as necessary.

This is how the section will appear with the Alert formatting:

![A snippet of the revised README showing GitHub Alert formatting](https://github.com/user-attachments/assets/cd3900bf-aef1-43cb-9502-e19b0a416097)