### PR TITLE
Backport the ability to list an application's routing table from 2.10.x to 2.9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,64 @@ This package exposes commands for [laminas-cli](https://docs.laminas.dev/laminas
 - `mezzio:module:create`: Create and register a middleware module with the application.
 - `mezzio:module:deregister`: Deregister a middleware module from the application.
 - `mezzio:module:register`: Register a middleware module with the application.
+- `mezzio:routes:list`: List the application's routing table.
+
+### Routes
+
+#### mezzio:routes:list
+
+This command lists the application's routing table.
+For each route, it prints its name, path, middleware, and any additional options, in a tabular format to the terminal.
+The routes are listed in no particular order, by default.
+
+The command supports several options, listed in the table below.
+
+<!-- markdownlint-disable MD037 -->
+| Command Long        | Command Short | Description                                                                                                                                                                                                                                                                                                                      |
+|---------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--format`          | `-f`          | Set the format of the command's output. The supported values are `table`, which is the default, and `json`. If you set the format to json, then we recommend using [jq](https://stedolan.github.io/jq/manual/) to query/filter the command's output.                                                                             |
+| `--sort`            | `-s`          | Sort the command's output. The supported values are `name` and `path`.                                                                                                                                                                                                                                                           |
+| `--supports-method` | `-m`          | Accepts a comma-separated list of one or more HTTP methods, and filters out routes which don't support those methods.                                                                                                                                                                                                            |
+| `--has-path`        | `-p`          | Accepts a comma-separated list of one or more paths, and filters out routes with paths that don't match. The paths can be a regular expression, supported by the `preg_*` functions. For example, "/,/api/ping,*/ping".                                                                                                            |
+| `--has-name`        | `-n`          | Accepts a comma-separated list of one or more names, and filters out routes with names that don't match. The names can be fixed strings, or regular expressions supported by the `preg_*` functions. For example, "user,user.register,*.register,user*".                                                                           |
+| `--has-middleware`  | `-w`          | Accepts a comma-separated list of one or more middleware classes, and filters out routes that do not require those classes. The classes can be fully-qualified, unqualified, or a regular expression, supported by the preg_* functions. For example, "\Mezzio\Middleware\LazyLoadingMiddleware,LazyLoadingMiddleware,\Mezzio*". |
+<!-- markdownlint-enable MD037 -->
+
+##### Usage Example
+
+Here is an example of what you can expect from running the command.
+
+```bash
+$ mezzio:routes:list
+
++----------+-----------+---------+ Routes ---------------------------------+
+| Name     | Path      | Methods | Middleware                              |
++----------+-----------+---------+-----------------------------------------+
+| api.ping | /api/ping | GET     | Mezzio\Middleware\LazyLoadingMiddleware |
+| home     | /         | GET     | Mezzio\Middleware\LazyLoadingMiddleware |
++----------+-----------+---------+-----------------------------------------+
+```
+
+Here is an example of what you can expect from running the command and setting the format to `json` (formatted with [jq][jq_url]).
+
+```bash
+$ mezzio:routes:list --format=json | jq
+
+[
+  {
+    "name": "api.ping",
+    "path": "/api/ping",
+    "methods": "GET",
+    "middleware": "Mezzio\\Middleware\\LazyLoadingMiddleware"
+  },
+  {
+    "name": "home",
+    "path": "/",
+    "methods": "GET",
+    "middleware": "Mezzio\\Middleware\\LazyLoadingMiddleware"
+  }
+]
+```
 
 > ### Previous versions
 >
@@ -72,3 +130,5 @@ return [
     ],
 ];
 ```
+
+[jq_url]: https://jqlang.github.io/jq/

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -25,6 +25,8 @@ use Mezzio\Tooling\Module\DeregisterCommand;
 use Mezzio\Tooling\Module\DeregisterCommandFactory;
 use Mezzio\Tooling\Module\RegisterCommand;
 use Mezzio\Tooling\Module\RegisterCommandFactory;
+use Mezzio\Tooling\Routes\ListRoutesCommand;
+use Mezzio\Tooling\Routes\ListRoutesCommandFactory;
 
 final class ConfigProvider
 {
@@ -52,6 +54,7 @@ final class ConfigProvider
                 'mezzio:module:create'                   => CreateCommand::class,
                 'mezzio:module:deregister'               => DeregisterCommand::class,
                 'mezzio:module:register'                 => RegisterCommand::class,
+                'mezzio:routes:list'                     => ListRoutesCommand::class,
             ],
         ];
     }
@@ -70,6 +73,7 @@ final class ConfigProvider
                 CreateHandlerCommand::class                     => CreateHandlerCommandFactory::class,
                 CreateMiddlewareCommand::class                  => CreateMiddlewareCommandFactory::class,
                 DeregisterCommand::class                        => DeregisterCommandFactory::class,
+                ListRoutesCommand::class                        => ListRoutesCommandFactory::class,
                 MigrateInteropMiddlewareCommand::class          => MigrateInteropMiddlewareCommandFactory::class,
                 MigrateMiddlewareToRequestHandlerCommand::class => MigrateMiddlewareToRequestHandlerCommandFactory::class,
                 RegisterCommand::class                          => RegisterCommandFactory::class,

--- a/src/Routes/ConfigLoaderInterface.php
+++ b/src/Routes/ConfigLoaderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Routes;
+
+interface ConfigLoaderInterface
+{
+    public function load(): void;
+}

--- a/src/Routes/Filter/RouteFilterOptions.php
+++ b/src/Routes/Filter/RouteFilterOptions.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Routes\Filter;
+
+use function get_object_vars;
+use function in_array;
+use function is_array;
+use function is_string;
+
+final class RouteFilterOptions
+{
+    private string $middleware;
+    private string $name;
+    private string $path;
+
+    /** @var array<array-key,string> */
+    private array $methods = [];
+
+    /**
+     * @param string|array<array-key,string> $methods
+     */
+    public function __construct(
+        string $middleware = '',
+        string $name = '',
+        string $path = '',
+        $methods = []
+    ) {
+        if (is_string($methods)) {
+            $this->methods = [$methods];
+        }
+        if (is_array($methods)) {
+            $this->methods = $methods;
+        }
+        $this->middleware = $middleware;
+        $this->name       = $name;
+        $this->path       = $path;
+    }
+
+    public function has(string $filterOption): bool
+    {
+        if (in_array($filterOption, ['middleware', 'name', 'path'])) {
+            return $this->$filterOption !== null;
+        }
+
+        if ($filterOption === 'methods') {
+            return [] !== $this->methods;
+        }
+
+        return false;
+    }
+
+    public function getMiddleware(): string
+    {
+        return $this->middleware;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return array<array-key,string>
+     */
+    public function getMethods(): array
+    {
+        return $this->methods;
+    }
+
+    public function toArray(): array
+    {
+        $values = [];
+        foreach (get_object_vars($this) as $key => $value) {
+            if (! empty($value)) {
+                $values[$key] = $value;
+            }
+        }
+
+        return $values;
+    }
+}

--- a/src/Routes/Filter/RoutesFilter.php
+++ b/src/Routes/Filter/RoutesFilter.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Routes\Filter;
+
+use ArrayIterator;
+use Exception;
+use FilterIterator;
+use Iterator;
+use Mezzio\Router\Route;
+
+use function array_filter;
+use function array_intersect;
+use function array_walk;
+use function get_class;
+use function in_array;
+use function is_array;
+use function is_string;
+use function preg_match;
+use function sprintf;
+use function str_replace;
+use function stripos;
+use function strtoupper;
+
+/**
+ * RoutesFilter filters a traversable list of Route objects based on any of the four Route criteria,
+ * those being the route's name, path, middleware, or supported method(s).
+
+ * @template TKey
+ * @template-covariant TValue
+ * @template TIterator as Iterator<TKey, TValue>
+ * @template-extends FilterIterator<TKey, TValue, TIterator>
+ */
+final class RoutesFilter extends FilterIterator
+{
+    /**
+     * An array storing the list of route options to filter a route on along with their respective values.
+     *
+     * The four allowed route options are: name, path, method, and middleware.
+     * Name and path can be a fixed string, such as user.profile, or a regular expression, such as user.*.
+     * Middleware can only contain a class name. Method can be either a string which contains one of the
+     * allowed HTTP methods, or an array of HTTP methods.
+     *
+     * @var array
+     */
+    private array $filterOptions;
+
+    /**
+     * @param ArrayIterator<int, Route> $routes
+     */
+    public function __construct(ArrayIterator $routes, array $filterOptions = [])
+    {
+        parent::__construct($routes);
+
+        $this->filterOptions = $filterOptions;
+
+        // Filter out any options that are, effectively, "empty".
+        $this->filterOptions = array_filter(
+            $this->filterOptions,
+            function ($value) {
+                return ! empty($value);
+            }
+        );
+    }
+
+    public function getFilterOptions(): array
+    {
+        return $this->filterOptions;
+    }
+
+    public function accept(): bool
+    {
+        /** @var Route $route */
+        $route = $this->getInnerIterator()->current();
+
+        if (empty($this->filterOptions)) {
+            return true;
+        }
+
+        if (! empty($this->filterOptions['name'])) {
+            return $route->getName() === $this->filterOptions['name']
+                || $this->matchesByRegex($route, 'name');
+        }
+
+        if (! empty($this->filterOptions['path'])) {
+            return $route->getPath() === $this->filterOptions['path']
+                || $this->matchesByRegex($route, 'path');
+        }
+
+        if (! empty($this->filterOptions['method'])) {
+            return $this->matchesByMethod($route);
+        }
+
+        if (! empty($this->filterOptions['middleware'])) {
+            return $this->matchesByMiddleware($route);
+        }
+
+        return false;
+    }
+
+    /**
+     * Match the route against a regular expression based on the field in $matchType.
+     *
+     * $matchType can be either "path" or "name".
+     */
+    public function matchesByRegex(Route $route, string $routeAttribute): bool
+    {
+        if ($routeAttribute === 'path') {
+            $path = (string) $this->filterOptions['path'];
+            return (bool) preg_match(
+                sprintf("/^%s/", str_replace('/', '\/', $path)),
+                $route->getPath()
+            );
+        }
+
+        if ($routeAttribute === 'name') {
+            return (bool) preg_match(
+                sprintf(
+                    "/%s/",
+                    (string) $this->filterOptions['name']
+                ),
+                $route->getName()
+            );
+        }
+
+        return false;
+    }
+
+    /**
+     * Match if the current route supports the method(s) supplied.
+     */
+    public function matchesByMethod(Route $route): bool
+    {
+        if ($route->allowsAnyMethod()) {
+            return true;
+        }
+
+        if ($this->filterOptions['method'] === Route::HTTP_METHOD_ANY) {
+            return true;
+        }
+
+        if (is_string($this->filterOptions['method'])) {
+            return in_array(
+                strtoupper($this->filterOptions['method']),
+                $route->getAllowedMethods() ?? []
+            );
+        }
+
+        if (is_array($this->filterOptions['method'])) {
+            array_walk(
+                $this->filterOptions['method'],
+                fn(string &$value) => $value = strtoupper($value)
+            );
+            return ! empty(array_intersect(
+                $this->filterOptions['method'],
+                $route->getAllowedMethods() ?? []
+            ));
+        }
+
+        return false;
+    }
+
+    /**
+     * This method checks if a route is handled by a given middleware class
+     *
+     * The function first checks if there is an exact match on the middleware
+     * class' name, then a partial match to any part of the class' name, and
+     * finally uses a regular expression to attempt a pattern match against
+     * the class' name. The intent is to perform checks from the least to the
+     * most computationally expensive, to avoid excessive overhead.
+     */
+    public function matchesByMiddleware(Route $route): bool
+    {
+        $middlewareClass   = get_class($route->getMiddleware());
+        $matchesMiddleware = (string) $this->filterOptions['middleware'];
+
+        try {
+            return $middlewareClass === $matchesMiddleware
+                || (bool) stripos($middlewareClass, $matchesMiddleware)
+                || (bool) preg_match(
+                    sprintf('/%s/', $matchesMiddleware),
+                    $middlewareClass
+                );
+        } catch (Exception $e) {
+            return false;
+        }
+    }
+}

--- a/src/Routes/ListRoutesCommand.php
+++ b/src/Routes/ListRoutesCommand.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Routes;
+
+use ArrayIterator;
+use Mezzio\Router\Route;
+use Mezzio\Router\RouteCollector;
+use Mezzio\Tooling\Routes\Filter\RoutesFilter;
+use Mezzio\Tooling\Routes\Sorter\RouteSorterByName;
+use Mezzio\Tooling\Routes\Sorter\RouteSorterByPath;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function get_class;
+use function implode;
+use function in_array;
+use function json_encode;
+use function strtolower;
+use function usort;
+
+class ListRoutesCommand extends Command
+{
+    /** @var array<int, Route>  */
+    private array $routes = [];
+
+    private ContainerInterface $container;
+
+    private ConfigLoaderInterface $configLoader;
+
+    /** @var array<string,string|array> */
+    private array $filterOptions = [];
+
+    private const HELP = <<<'EOT'
+        Prints the application's routing table.
+        
+        For each route, it prints its name, path, middleware, and any additional 
+        options, in a tabular format to the terminal. The routes are listed in no 
+        particular order, by default. 
+        EOT;
+
+    private const HELP_OPT_FORMAT = <<<'EOT'
+        These set the format of the command's output. The supported values are 
+        `table`, which is the default, and `json`.
+        EOT;
+
+    private const HELP_OPT_HAS_MIDDLEWARE = <<<'EOT'
+        Filters out routes by middleware class. This option accepts a 
+        comma-separated list of one or more middleware classes. The class names 
+        can be fully-qualified, unqualified class names, or a regular expression, 
+        supported by the preg_* functions. For example, 
+        "\Mezzio\Middleware\LazyLoadingMiddleware,LazyLoadingMiddleware,\Mezzio*".
+        EOT;
+
+    private const HELP_OPT_HAS_NAME = <<<'EOT'
+        Filters out routes by name. This option accepts a comma-separated list of 
+        one or more names. The names can be fixed-strings or regular expressions 
+        supported by the preg_* functions. For example, 
+        "user,user.register,*.register,user*".
+        EOT;
+
+    private const HELP_OPT_HAS_PATH = <<<'EOT'
+        Filter out routes by path. This option accepts a comma-separated list of 
+        one or more paths. The paths can be a fixed-string or a regular expression, 
+        supported by the preg_* functions. For example, "/,/api/ping,*/ping".
+        EOT;
+
+    private const HELP_OPT_SORT = <<<'EOT'
+        Sort the command's output. The supported values are "name" and "path".
+        EOT;
+
+    private const HELP_OPT_SUPPORTS_METHOD = <<<'EOT'
+        Filters out routes by HTTP method.  This option accepts a comma-separated 
+        list of one or more HTTP methods.
+        EOT;
+
+    private const MSG_EMPTY_ROUTING_TABLE = "There are no routes in the application's routing table.";
+
+    /** @var null|string Cannot be defined explicitly due to parent class */
+    public static $defaultName = 'mezzio:routes:list';
+
+    public function __construct(
+        ContainerInterface $container,
+        ConfigLoaderInterface $configLoader
+    ) {
+        $this->container    = $container;
+        $this->configLoader = $configLoader;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription("Print the application's routing table.");
+        $this->setHelp(self::HELP);
+
+        $this->addOption(
+            'format',
+            null,
+            InputOption::VALUE_REQUIRED,
+            self::HELP_OPT_FORMAT,
+            'table'
+        );
+
+        $this->addOption(
+            'sort',
+            null,
+            InputOption::VALUE_REQUIRED,
+            self::HELP_OPT_SORT,
+            'name'
+        );
+
+        // Routing table filter options
+        $this->addOption(
+            'has-middleware',
+            null,
+            InputOption::VALUE_REQUIRED,
+            self::HELP_OPT_HAS_MIDDLEWARE,
+            false
+        );
+        $this->addOption(
+            'has-name',
+            null,
+            InputOption::VALUE_REQUIRED,
+            self::HELP_OPT_HAS_NAME,
+            false
+        );
+        $this->addOption(
+            'has-path',
+            null,
+            InputOption::VALUE_REQUIRED,
+            self::HELP_OPT_HAS_PATH,
+            false
+        );
+        $this->addOption(
+            'supports-method',
+            null,
+            InputOption::VALUE_REQUIRED,
+            self::HELP_OPT_SUPPORTS_METHOD,
+            false
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $result = 0;
+
+        $this->configLoader->load();
+
+        /** @var RouteCollector $routeCollector */
+        $routeCollector = $this->container->get(RouteCollector::class);
+        $this->routes   = $routeCollector->getRoutes();
+
+        if ([] === $this->routes) {
+            $output->writeln(self::MSG_EMPTY_ROUTING_TABLE);
+            return $result;
+        }
+
+        $format = strtolower((string) $input->getOption('format'));
+
+        $sorter = $this->getSortOrder($input) === 'name'
+            ? new RouteSorterByName()
+            : new RouteSorterByPath();
+        usort($this->routes, $sorter);
+
+        $this->filterOptions = [
+            'method'     => strtolower((string) $input->getOption('supports-method')),
+            'middleware' => strtolower((string) $input->getOption('has-middleware')),
+            'name'       => strtolower((string) $input->getOption('has-name')),
+            'path'       => strtolower((string) $input->getOption('has-path')),
+        ];
+
+        switch ($format) {
+            case 'json':
+                $output->writeln(json_encode($this->getRows(true)));
+                break;
+            case 'table':
+            case '':
+                $table = new Table($output);
+                $table->setHeaderTitle('Routes')
+                    ->setHeaders(['Name', 'Path', 'Methods', 'Middleware'])
+                    ->setRows($this->getRows(false));
+                $table->render();
+                break;
+            case 'format':
+            default:
+                $result = -1;
+                $output->writeln(
+                    "Invalid output format supplied. Valid options are 'table' and 'json'"
+                );
+        }
+
+        return $result;
+    }
+
+    public function getRows(bool $requireNames = false): array
+    {
+        $rows = [];
+
+        $routesIterator = new RoutesFilter(
+            new ArrayIterator($this->routes),
+            $this->filterOptions
+        );
+
+        /** @var Route $route */
+        foreach ($routesIterator as $route) {
+            $routeMethods = implode(',', $route->getAllowedMethods() ?? []);
+            if ($requireNames) {
+                $rows[] = [
+                    'name'       => $route->getName(),
+                    'path'       => $route->getPath(),
+                    'methods'    => $routeMethods,
+                    'middleware' => get_class($route->getMiddleware()),
+                ];
+            } else {
+                $rows[] = [
+                    $route->getName(),
+                    $route->getPath(),
+                    $routeMethods,
+                    get_class($route->getMiddleware()),
+                ];
+            }
+        }
+
+        return $rows;
+    }
+
+    public function getSortOrder(InputInterface $input): string
+    {
+        $sortOrder = strtolower((string) $input->getOption('sort'));
+        return ! in_array($sortOrder, ['name', 'path'])
+            ? 'name'
+            : $sortOrder;
+    }
+}

--- a/src/Routes/ListRoutesCommandFactory.php
+++ b/src/Routes/ListRoutesCommandFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Routes;
+
+use Mezzio\Application;
+use Mezzio\MiddlewareFactory;
+use Mezzio\Tooling\Routes\RoutesFileConfigLoader;
+use Psr\Container\ContainerInterface;
+
+final class ListRoutesCommandFactory
+{
+    public function __invoke(ContainerInterface $container): ListRoutesCommand
+    {
+        /** @var Application $application */
+        $application = $container->get(Application::class);
+
+        /** @var MiddlewareFactory $factory */
+        $factory = $container->get(MiddlewareFactory::class);
+
+        $configLoader = new RoutesFileConfigLoader('config/routes.php', $application, $factory, $container);
+
+        return new ListRoutesCommand($container, $configLoader);
+    }
+}

--- a/src/Routes/RoutesFileConfigLoader.php
+++ b/src/Routes/RoutesFileConfigLoader.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Routes;
+
+use InvalidArgumentException;
+use Mezzio\Application;
+use Mezzio\MiddlewareFactory;
+use Psr\Container\ContainerInterface;
+
+use function file_exists;
+
+final class RoutesFileConfigLoader implements ConfigLoaderInterface
+{
+    private string $configFilePath;
+    private Application $app;
+    private MiddlewareFactory $middlewareFactory;
+    private ContainerInterface $container;
+
+    public function __construct(
+        string $configFilePath,
+        Application $app,
+        MiddlewareFactory $middlewareFactory,
+        ContainerInterface $container,
+    ) {
+        $this->configFilePath    = $configFilePath;
+        $this->app               = $app;
+        $this->middlewareFactory = $middlewareFactory;
+        $this->container         = $container;
+    }
+
+    public function load(): void
+    {
+        if (! file_exists($this->configFilePath)) {
+            throw new InvalidArgumentException("Configuration file not found: {$this->configFilePath}");
+        }
+
+        (require $this->configFilePath)(
+            $this->app,
+            $this->middlewareFactory,
+            $this->container
+        );
+    }
+}

--- a/src/Routes/Sorter/RouteSorterByName.php
+++ b/src/Routes/Sorter/RouteSorterByName.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Routes\Sorter;
+
+use Mezzio\Router\Route;
+
+final class RouteSorterByName
+{
+    public function __invoke(Route $routeOne, Route $routeTwo): int
+    {
+        return $routeOne->getName() <=> $routeTwo->getName();
+    }
+}

--- a/src/Routes/Sorter/RouteSorterByPath.php
+++ b/src/Routes/Sorter/RouteSorterByPath.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Tooling\Routes\Sorter;
+
+use Mezzio\Router\Route;
+
+final class RouteSorterByPath
+{
+    public function __invoke(Route $routeOne, Route $routeTwo): int
+    {
+        return $routeOne->getPath() <=> $routeTwo->getPath();
+    }
+}

--- a/test/Routes/Filter/RouteFilterOptionsTest.php
+++ b/test/Routes/Filter/RouteFilterOptionsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Tooling\Routes\Filter;
+
+use Mezzio\Tooling\Routes\Filter\RouteFilterOptions;
+use MezzioTest\Tooling\Routes\Middleware\ExpressMiddleware;
+use PHPUnit\Framework\TestCase;
+
+class RouteFilterOptionsTest extends TestCase
+{
+    public function testCanInitialiseOptionsCorrectly(): void
+    {
+        $options = [
+            'middleware' => ExpressMiddleware::class,
+            'name'       => 'home',
+            'path'       => '/user',
+            'methods'    => ['GET'],
+        ];
+
+        $routeFilterOptions = new RouteFilterOptions(
+            $options['middleware'],
+            $options['name'],
+            $options['path'],
+            $options['methods']
+        );
+
+        $this->assertTrue($routeFilterOptions->has('middleware'));
+        $this->assertTrue($routeFilterOptions->has('name'));
+        $this->assertTrue($routeFilterOptions->has('path'));
+        $this->assertTrue($routeFilterOptions->has('methods'));
+
+        $this->assertSame($options['middleware'], $routeFilterOptions->getMiddleware());
+        $this->assertSame($options['name'], $routeFilterOptions->getName());
+        $this->assertSame($options['path'], $routeFilterOptions->getPath());
+        $this->assertSame($options['methods'], $routeFilterOptions->getMethods());
+    }
+
+    /**
+     * @param array<array-key, mixed> $options
+     * @param array<array-key, mixed> $expectedResult
+     * @dataProvider initDataProvider
+     */
+    public function testCanGetArrayRepresentation(array $options, array $expectedResult): void
+    {
+        /** @var string $middleware */
+        $middleware = $options['middleware'] ?? '';
+
+        /** @var string $name */
+        $name = $options['name'] ?? '';
+
+        /** @var string $path */
+        $path = $options['path'] ?? '';
+
+        /** @var array<array-key, string> $methods */
+        $methods = $options['methods'] ?? [];
+
+        $routeFilterOptions = new RouteFilterOptions($middleware, $name, $path, $methods);
+
+        $this->assertSame($expectedResult, $routeFilterOptions->toArray());
+    }
+
+    /**
+     * @return array<array-key, array<array-key,array<string,string|array<array-key,string>>>>
+     */
+    public function initDataProvider(): array
+    {
+        return [
+            [
+                [
+                    'middleware' => ExpressMiddleware::class,
+                    'name'       => 'home',
+                    'path'       => '/user',
+                    'methods'    => ['GET'],
+                ],
+                [
+                    'middleware' => ExpressMiddleware::class,
+                    'name'       => 'home',
+                    'path'       => '/user',
+                    'methods'    => ['GET'],
+                ],
+            ],
+            [
+                [
+                    'middleware' => ExpressMiddleware::class,
+                    'methods'    => ['GET'],
+                ],
+                [
+                    'middleware' => ExpressMiddleware::class,
+                    'methods'    => ['GET'],
+                ],
+            ],
+            [
+                [
+                    'path'    => '/user',
+                    'methods' => ['GET'],
+                ],
+                [
+                    'path'    => '/user',
+                    'methods' => ['GET'],
+                ],
+            ],
+            [
+                [
+                    'path'    => '/user',
+                    'methods' => 'GET',
+                ],
+                [
+                    'path'    => '/user',
+                    'methods' => ['GET'],
+                ],
+            ],
+            [
+                [
+                    'middleware' => ExpressMiddleware::class,
+                    'name'       => 'home',
+                ],
+                [
+                    'middleware' => ExpressMiddleware::class,
+                    'name'       => 'home',
+                ],
+            ],
+            [
+                [],
+                [],
+            ],
+        ];
+    }
+}

--- a/test/Routes/ListRoutesCommandFactoryTest.php
+++ b/test/Routes/ListRoutesCommandFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Tooling\Routes;
+
+use Mezzio\Application;
+use Mezzio\MiddlewareFactory;
+use Mezzio\Tooling\Routes\ListRoutesCommand;
+use Mezzio\Tooling\Routes\ListRoutesCommandFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class ListRoutesCommandFactoryTest extends TestCase
+{
+    public function testCanInstantiateListRoutesCommandObject(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->atMost(2))
+            ->method('get')
+            ->willReturnOnConsecutiveCalls(
+                $this->createMock(Application::class),
+                $this->createMock(MiddlewareFactory::class),
+            );
+        $factory = new ListRoutesCommandFactory();
+
+        $this->assertInstanceOf(
+            ListRoutesCommand::class,
+            $factory->__invoke($container)
+        );
+    }
+}

--- a/test/Routes/ListRoutesCommandTest.php
+++ b/test/Routes/ListRoutesCommandTest.php
@@ -1,0 +1,493 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Tooling\Routes;
+
+use Mezzio\Router\Route;
+use Mezzio\Router\RouteCollector;
+use Mezzio\Tooling\Routes\ConfigLoaderInterface;
+use Mezzio\Tooling\Routes\ListRoutesCommand;
+use MezzioTest\Tooling\Routes\Middleware\ExpressMiddleware;
+use MezzioTest\Tooling\Routes\Middleware\SimpleMiddleware;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+
+use function str_replace;
+use function strtoupper;
+
+class ListRoutesCommandTest extends TestCase
+{
+    /** @var (InputInterface&MockObject) */
+    private $input;
+
+    /** @var (ConsoleOutputInterface&MockObject) */
+    private $output;
+
+    /** @var (RouteCollector&MockObject) */
+    private $routeCollection;
+
+    /** @var (ContainerInterface&MockObject) */
+    private $container;
+
+    private ListRoutesCommand $command;
+
+    protected function setUp(): void
+    {
+        /** @var ConfigLoaderInterface $configLoader */
+        $configLoader = $this->createMock(ConfigLoaderInterface::class);
+
+        /** @var ContainerInterface $container */
+        $container = $this->createMock(ContainerInterface::class);
+
+        $this->input           = $this->createMock(InputInterface::class);
+        $this->output          = $this->createMock(ConsoleOutputInterface::class);
+        $this->routeCollection = $this->createMock(RouteCollector::class);
+        $this->command         = new ListRoutesCommand($container, $configLoader);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    private function reflectExecuteMethod(): ReflectionMethod
+    {
+        return new ReflectionMethod($this->command, 'execute');
+    }
+
+    public function testConfigureSetsExpectedDescription(): void
+    {
+        self::assertStringContainsString(
+            "Print the application's routing table.",
+            $this->command->getDescription()
+        );
+    }
+
+    /**
+     * @return mixed
+     * @throws ReflectionException
+     * @param class-string $class
+     */
+    private function getConstantValue(string $const, string $class = ListRoutesCommand::class)
+    {
+        $r = new ReflectionClass($class);
+
+        return $r->getConstant($const);
+    }
+
+    public function testConfigureSetsExpectedHelp(): void
+    {
+        self::assertEquals($this->getConstantValue('HELP'), $this->command->getHelp());
+    }
+
+    public function testConfigureSetsExpectedOptions(): void
+    {
+        $definition = $this->command->getDefinition();
+
+        $args = [
+            'format',
+            'has-middleware',
+            'has-name',
+            'has-path',
+            'sort',
+            'supports-method',
+        ];
+
+        foreach ($args as $arg) {
+            self::assertTrue($definition->hasOption($arg));
+            $option = $definition->getOption($arg);
+            self::assertTrue($option->isValueRequired());
+            self::assertTrue($option->acceptValue());
+            self::assertEquals(
+                $this->getConstantValue(
+                    'HELP_OPT_' . strtoupper(str_replace('-', '_', $arg))
+                ),
+                $option->getDescription()
+            );
+        }
+    }
+
+    /**
+     * @phpcs:ignore Generic.Files.LineLength.TooLong
+     * @throws ReflectionException
+     */
+    public function testSuccessfulExecutionEmitsExpectedOutput(): void
+    {
+        $routes    = [
+            new Route("/", new SimpleMiddleware(), ['GET'], 'home'),
+            new Route("/", new ExpressMiddleware(), ['GET'], 'home'),
+        ];
+        $collector = $this->createMock(RouteCollector::class);
+        $collector
+            ->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($routes);
+
+        /** @var ContainerInterface&MockObject $container */
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(RouteCollector::class)
+            ->willReturn($collector);
+
+        /** @var ConfigLoaderInterface&MockObject $configLoader */
+        $configLoader  = $this->createMock(ConfigLoaderInterface::class);
+        $this->command = new ListRoutesCommand($container, $configLoader);
+
+        $outputFormatter = new OutputFormatter(false);
+
+        $this->output
+            ->method('getFormatter')
+            ->willReturn($outputFormatter);
+
+        // phpcs:disable Generic.Files.LineLength
+        $this->output
+            ->expects($this->atMost(7))
+            ->method('writeln');
+        // phpcs:enable
+        $this->input
+            ->method('getOption')
+            ->willReturnOnConsecutiveCalls(
+                'table',
+                false,
+                false,
+                false,
+                false
+            );
+
+        $method = $this->reflectExecuteMethod();
+
+        self::assertSame(
+            0,
+            $method->invoke(
+                $this->command,
+                $this->input,
+                $this->output
+            )
+        );
+    }
+
+    public function testRendersAnEmptyResultWhenNoRoutesArePresent(): void
+    {
+        $collector = $this->createMock(RouteCollector::class);
+
+        /** @var ContainerInterface&MockObject $container */
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(RouteCollector::class)
+            ->willReturn($collector);
+
+        /** @var ConfigLoaderInterface&MockObject $configLoader */
+        $configLoader = $this->createMock(ConfigLoaderInterface::class);
+        $configLoader
+            ->expects($this->once())
+            ->method('load');
+
+        $this->command = new ListRoutesCommand($container, $configLoader);
+
+        $this->input
+            ->method('getOption')
+            ->with('format')
+            ->willReturnOnConsecutiveCalls('table', false);
+        $this->output
+            ->expects($this->once())
+            ->method('writeln')
+            ->with(
+                "There are no routes in the application's routing table."
+            );
+
+        $method = $this->reflectExecuteMethod();
+
+        self::assertSame(
+            0,
+            $method->invoke(
+                $this->command,
+                $this->input,
+                $this->output
+            )
+        );
+    }
+
+    public function testRendersRoutesAsJsonWhenFormatSetToJson(): void
+    {
+        $routes    = [
+            new Route("/", new SimpleMiddleware(), ['GET'], 'home'),
+            new Route("/", new ExpressMiddleware(), ['GET'], 'home'),
+        ];
+        $collector = $this->createMock(RouteCollector::class);
+        $collector
+            ->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($routes);
+
+        /** @var ContainerInterface&MockObject $container */
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(RouteCollector::class)
+            ->willReturn($collector);
+
+        /** @var ConfigLoaderInterface&MockObject $configLoader */
+        $configLoader = $this->createMock(ConfigLoaderInterface::class);
+        $configLoader
+            ->expects($this->once())
+            ->method('load');
+
+        $this->command = new ListRoutesCommand($container, $configLoader);
+
+        $this->input
+            ->method('getOption')
+            ->willReturnOnConsecutiveCalls(
+                'json', // format
+                false, // supports-method
+                false, // has-middleware
+                false, // has-name
+                false, // has-path
+                false
+            );
+        $this->output
+            ->expects($this->atMost(2))
+            ->method('writeln');
+
+        $method = $this->reflectExecuteMethod();
+
+        self::assertSame(
+            0,
+            $method->invoke(
+                $this->command,
+                $this->input,
+                $this->output
+            )
+        );
+    }
+
+    /**
+     * @dataProvider invalidFormatDataProvider
+     * @throws ReflectionException
+     */
+    public function testThatOnlyAllowedFormatsCanBeSupplied(string $format): void
+    {
+        $routes    = [
+            new Route("/", new SimpleMiddleware(), ['GET'], 'home'),
+            new Route("/", new ExpressMiddleware(), ['GET'], 'home'),
+        ];
+        $collector = $this->createMock(RouteCollector::class);
+        $collector
+            ->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($routes);
+
+        /** @var ContainerInterface&MockObject $container */
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(RouteCollector::class)
+            ->willReturn($collector);
+
+        /** @var ConfigLoaderInterface $configLoader */
+        $configLoader  = $this->createMock(ConfigLoaderInterface::class);
+        $this->command = new ListRoutesCommand($container, $configLoader);
+
+        $this->input
+            ->method('getOption')
+            ->willReturnOnConsecutiveCalls(
+                $format, // format
+                false, // has-middleware
+                false, // supports-method
+                false, // has-name
+                false, // has-path
+                false    // sort
+            );
+        $this->output
+            ->expects($this->once())
+            ->method('writeln')
+            ->with(
+                "Invalid output format supplied. Valid options are 'table' and 'json'"
+            );
+
+        $method = $this->reflectExecuteMethod();
+
+        self::assertSame(
+            -1,
+            $method->invoke(
+                $this->command,
+                $this->input,
+                $this->output
+            )
+        );
+    }
+
+    /**
+     * @return array<array-key,array<array-key,string>>
+     */
+    public function invalidFormatDataProvider(): array
+    {
+        return [
+            [
+                'rabbits',
+            ],
+            [
+                'tables',
+            ],
+            [
+                'toml',
+            ],
+            [
+                'yaml',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider sortRoutingTableDataProvider
+     * @throws ReflectionException
+     */
+    public function testCanSortResults(string $sortOrder): void
+    {
+        $routes                = [
+            new Route("/contact", new SimpleMiddleware(), ['GET'], 'contact'),
+            new Route("/", new ExpressMiddleware(), ['GET'], 'home'),
+        ];
+        $this->routeCollection = $this->createMock(RouteCollector::class);
+        $this->routeCollection
+            ->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($routes);
+
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->container
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn(
+                $this->routeCollection,
+            );
+
+        /** @var ConfigLoaderInterface $configLoader */
+        $configLoader  = $this->createMock(ConfigLoaderInterface::class);
+        $this->command = new ListRoutesCommand($this->container, $configLoader);
+
+        $this->input
+            ->method('getOption')
+            ->willReturnOnConsecutiveCalls(
+                'json', // format
+                $sortOrder, // sort
+                false, // supports-method
+                false, // has-middleware
+                false, // has-name
+                false  // has-path
+            );
+        $this->output
+            ->expects($this->atMost(2))
+            ->method('writeln');
+
+        $method = $this->reflectExecuteMethod();
+
+        self::assertSame(
+            0,
+            $method->invoke(
+                $this->command,
+                $this->input,
+                $this->output
+            )
+        );
+    }
+
+    /**
+     * @return array<array-key, array<array-key,string>>
+     */
+    public function sortRoutingTableDataProvider(): array
+    {
+        // phpcs:disable Generic.Files.LineLength
+        return [
+            [
+                'name',
+                '[{"name":"contact","path":"\/contact","methods":"GET","middleware":"MezzioTest\\\\Tooling\\\\Routes\\\\Middleware\\\\SimpleMiddleware"},{"name":"home","path":"\/","methods":"GET","middleware":"MezzioTest\\\\Tooling\\\\Routes\\\\Middleware\\\\ExpressMiddleware"}]',
+            ],
+            [
+                'path',
+                '[{"name":"home","path":"\/","methods":"GET","middleware":"MezzioTest\\\\Tooling\\\\Routes\\\\Middleware\\\\ExpressMiddleware"},{"name":"contact","path":"\/contact","methods":"GET","middleware":"MezzioTest\\\\Tooling\\\\Routes\\\\Middleware\\\\SimpleMiddleware"}]',
+            ],
+        ];
+        // phpcs:enable
+    }
+
+    /**
+     * @dataProvider filterRoutingTableDataProvider
+     */
+    public function testCanFilterRoutingTable(array $filterOptions): void
+    {
+        $routes = [
+            new Route("/", new SimpleMiddleware(), ['GET'], 'home'),
+            new Route("/", new ExpressMiddleware(), ['GET'], 'home'),
+        ];
+
+        $routeCollection = $this->createMock(RouteCollector::class);
+        $routeCollection
+            ->expects($this->once())
+            ->method('getRoutes')
+            ->willReturn($routes);
+
+        /** @var ContainerInterface&MockObject $container */
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(RouteCollector::class)
+            ->willReturn($routeCollection);
+
+        /** @var ConfigLoaderInterface $configLoader */
+        $configLoader  = $this->createMock(ConfigLoaderInterface::class);
+        $this->command = new ListRoutesCommand($container, $configLoader);
+
+        $this->input
+            ->method('getOption')
+            ->willReturnOnConsecutiveCalls(
+                'json', // format
+                false, // sort
+                false, // supports-method
+                $filterOptions['middleware'], // has-middleware
+                false, // has-name
+                false                           // has-path
+            );
+
+        $this->output
+            ->expects($this->atMost(2))
+            ->method('writeln');
+
+        $method = $this->reflectExecuteMethod();
+
+        self::assertSame(
+            0,
+            $method->invoke(
+                $this->command,
+                $this->input,
+                $this->output
+            )
+        );
+    }
+
+    /**
+     * @psalm-return array<array-key, array<array<string, string>>>
+     */
+    public static function filterRoutingTableDataProvider(): array
+    {
+        // phpcs:disable Generic.Files.LineLength
+        return [
+            [
+                ['middleware' => 'ExpressMiddleware'],
+            ],
+        ];
+        // phpcs:enable
+    }
+}

--- a/test/Routes/Middleware/ExpressMiddleware.php
+++ b/test/Routes/Middleware/ExpressMiddleware.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Tooling\Routes\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ExpressMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/test/Routes/Middleware/SimpleMiddleware.php
+++ b/test/Routes/Middleware/SimpleMiddleware.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Tooling\Routes\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class SimpleMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/test/Routes/RoutesFilterTest.php
+++ b/test/Routes/RoutesFilterTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Tooling\Routes;
+
+use ArrayIterator;
+use Mezzio\Router\Route;
+use Mezzio\Tooling\Routes\Filter\RoutesFilter;
+use MezzioTest\Tooling\Routes\Middleware\ExpressMiddleware;
+use MezzioTest\Tooling\Routes\Middleware\SimpleMiddleware;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+use function var_export;
+
+class RoutesFilterTest extends TestCase
+{
+    /** @var array<int,Route> */
+    private array $routes = [];
+
+    public function setUp(): void
+    {
+        $this->routes = [
+            new Route(
+                "/user/profile",
+                new SimpleMiddleware(),
+                ['GET'],
+                'user.profile'
+            ),
+            new Route(
+                "/",
+                new ExpressMiddleware(),
+                ['GET'],
+                'home'
+            ),
+            new Route(
+                "/login",
+                new ExpressMiddleware(),
+                ['GET'],
+                'user.login'
+            ),
+            new Route(
+                "/logout",
+                new ExpressMiddleware(),
+                ['GET'],
+                'user.logout'
+            ),
+            new Route(
+                "/logout",
+                new ExpressMiddleware(),
+                ['GET', 'POST'],
+                'user.logout'
+            ),
+            new Route(
+                "/logout",
+                new ExpressMiddleware(),
+                Route::HTTP_METHOD_ANY,
+                'user.logout'
+            ),
+        ];
+    }
+
+    public function testFiltersOutEmptyOptions(): void
+    {
+        $routeFilter = new RoutesFilter(
+            new ArrayIterator($this->routes),
+            [
+                'middleware' => null,
+                'name'       => '',
+                'path'       => '/user',
+            ]
+        );
+
+        $this->assertSame(
+            ['path' => '/user'],
+            $routeFilter->getFilterOptions()
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $filterOptions
+     * @dataProvider validFilterDataProvider
+     */
+    public function testCanFilterRoutesWithStringSearchExpression(
+        int $expectedNumberOfRoutes,
+        array $filterOptions = []
+    ): void {
+        $this->setUp();
+
+        $routeFilter = new RoutesFilter(new ArrayIterator($this->routes), $filterOptions);
+
+        $this->assertCount(
+            $expectedNumberOfRoutes,
+            $routeFilter,
+            sprintf(
+                'Filtered with %s',
+                var_export($filterOptions, true)
+            )
+        );
+    }
+
+    /**
+     * @psalm-return array<array-key, array{0: int, 1: array<string, mixed>}>
+     */
+    public function validFilterDataProvider(): array
+    {
+        return [
+            [
+                5,
+                [
+                    'middleware' => 'ExpressMiddleware',
+                ],
+            ],
+            [
+                6,
+                [
+                    'middleware' => 'Tooling',
+                ],
+            ],
+            [
+                6,
+                [
+                    'middleware' => 'Tooling.*Middleware',
+                ],
+            ],
+            [
+                5,
+                [
+                    'middleware' => ExpressMiddleware::class,
+                ],
+            ],
+            [
+                1,
+                [
+                    'name' => 'home',
+                ],
+            ],
+            [
+                5,
+                [
+                    'name' => 'user.*',
+                ],
+            ],
+            [
+                1,
+                [
+                    'path' => '/user',
+                ],
+            ],
+            [
+                4,
+                [
+                    'path' => '/log.*',
+                ],
+            ],
+            [
+                6,
+                [
+                    'path' => '/',
+                ],
+            ],
+            [
+                6,
+                [
+                    'method' => 'GET',
+                ],
+            ],
+            [
+                6,
+                [
+                    'method' => Route::HTTP_METHOD_ANY,
+                ],
+            ],
+            [
+                6,
+                [
+                    'method' => 'get',
+                ],
+            ],
+            [
+                2,
+                [
+                    'method' => 'post',
+                ],
+            ],
+            /*[
+                6,
+                [
+                    'method' => ['POST', 'GET'],
+                ],
+            ],
+            [
+                2,
+                [
+                    'method' => ['POST'],
+                ],
+            ],
+            [
+                6,
+                [
+                    'method' => ['GET'],
+                ],
+            ],
+            [
+                1,
+                [
+                    'method' => ['PATCH'],
+                ],
+            ],
+            [
+                2,
+                [
+                    'method' => ['PATCH', 'POST'],
+                ],
+            ],
+            [
+                2,
+                [
+                    'method' => ['patch', 'post'],
+                ],
+            ],
+            [
+                1,
+                [
+                    'method' => ['patch'],
+                ],
+            ],*/
+        ];
+    }
+}

--- a/test/Routes/Sorter/RouteSorterByNameTest.php
+++ b/test/Routes/Sorter/RouteSorterByNameTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Tooling\Routes\Sorter;
+
+use Mezzio\Router\Route;
+use Mezzio\Tooling\Routes\Sorter\RouteSorterByName;
+use MezzioTest\Tooling\Routes\Middleware\ExpressMiddleware;
+use MezzioTest\Tooling\Routes\Middleware\SimpleMiddleware;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+use function sprintf;
+use function usort;
+
+class RouteSorterByNameTest extends TestCase
+{
+    /** @var Route[] */
+    private array $routes = [];
+
+    public function setUp(): void
+    {
+        $this->routes = [
+            new Route(
+                "/user/profile",
+                new SimpleMiddleware(),
+                ['GET'],
+                'user.profile'
+            ),
+            new Route(
+                "/",
+                new ExpressMiddleware(),
+                ['GET'],
+                'home'
+            ),
+            new Route(
+                "/login",
+                new ExpressMiddleware(),
+                ['GET'],
+                'user.login'
+            ),
+            new Route(
+                "/logout",
+                new ExpressMiddleware(),
+                ['GET'],
+                'user.logout'
+            ),
+            new Route(
+                "/logout",
+                new ExpressMiddleware(),
+                ['GET', 'POST'],
+                'user.logout'
+            ),
+            new Route(
+                "/logout",
+                new ExpressMiddleware(),
+                Route::HTTP_METHOD_ANY,
+                'user.logout'
+            ),
+        ];
+    }
+
+    public function testCanSortRoutesByName(): void
+    {
+        $sorter = new RouteSorterByName();
+        usort($this->routes, $sorter);
+
+        $this->assertCount(6, $this->routes);
+    }
+
+    public function testCanSortRoutesByNameInAscendingOrderOfName(): void
+    {
+        $sorter = new RouteSorterByName();
+        usort($this->routes, $sorter);
+
+        $this->assertCount(6, $this->routes);
+
+        $sortedPaths = [
+            'home',
+            'user.login',
+            'user.logout',
+            'user.logout',
+            'user.logout',
+            'user.profile',
+        ];
+        $maxPaths    = count($sortedPaths) - 1;
+        /** @psalm-suppress InvalidArrayOffset */
+        for ($i = 0; $i < $maxPaths; $i++) {
+            $this->assertSame(
+                $sortedPaths[$i],
+                $this->routes[$i]->getName(),
+                sprintf("Names for element %d don't match", $i)
+            );
+        }
+    }
+
+    public function testWillReturnAnEmptyArrayIfNoRoutesAreProvided(): void
+    {
+        $routes = [];
+        $sorter = new RouteSorterByName();
+        usort($routes, $sorter);
+
+        $this->assertEmpty($routes);
+    }
+}

--- a/test/Routes/Sorter/RouteSorterByPathTest.php
+++ b/test/Routes/Sorter/RouteSorterByPathTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Tooling\Routes\Sorter;
+
+use Mezzio\Router\Route;
+use Mezzio\Tooling\Routes\Sorter\RouteSorterByPath;
+use MezzioTest\Tooling\Routes\Middleware\ExpressMiddleware;
+use MezzioTest\Tooling\Routes\Middleware\SimpleMiddleware;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+use function sprintf;
+use function usort;
+
+class RouteSorterByPathTest extends TestCase
+{
+    /** @var Route[] */
+    private array $routes = [];
+
+    public function setUp(): void
+    {
+        $this->routes = [
+            new Route(
+                "/user/profile",
+                new SimpleMiddleware(),
+                ['GET'],
+                'user.profile'
+            ),
+            new Route(
+                "/",
+                new ExpressMiddleware(),
+                ['GET'],
+                'home'
+            ),
+            new Route(
+                "/login",
+                new ExpressMiddleware(),
+                ['GET'],
+                'user.login'
+            ),
+            new Route(
+                "/logout",
+                new ExpressMiddleware(),
+                ['GET'],
+                'user.logout'
+            ),
+            new Route(
+                "/logout",
+                new ExpressMiddleware(),
+                ['GET', 'POST'],
+                'user.logout'
+            ),
+            new Route(
+                "/logout",
+                new ExpressMiddleware(),
+                Route::HTTP_METHOD_ANY,
+                'user.logout'
+            ),
+        ];
+    }
+
+    public function testCanSortRoutesByNameInAscendingOrderOfName(): void
+    {
+        $sorter = new RouteSorterByPath();
+        usort($this->routes, $sorter);
+
+        $this->assertCount(6, $this->routes);
+
+        $sortedPaths = [
+            '/',
+            '/login',
+            '/logout',
+            '/logout',
+            '/logout',
+            '/user/profile',
+        ];
+        $maxPaths    = count($sortedPaths) - 1;
+        /** @psalm-suppress InvalidArrayOffset */
+        for ($i = 0; $i < $maxPaths; $i++) {
+            $this->assertSame(
+                $sortedPaths[$i],
+                $this->routes[$i]->getPath(),
+                sprintf("Paths for element %d don't match", $i)
+            );
+        }
+    }
+
+    public function testWillReturnAnEmptyArrayIfNoRoutesAreProvided(): void
+    {
+        $routes = [];
+        $sorter = new RouteSorterByPath();
+        usort($routes, $sorter);
+
+        $this->assertEmpty($routes);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

The change, in short, backports the new Mezzio command: routes:list from 2.10.x to 2.9.x (#52). When invoked, it will print the application's routing table akin to what Symfony and Laravel provide, providing a wealth of ways to filter and sort the returned information, so that it's as meaningful as possible..