### PR TITLE
Fix psr-4 empty array being serialized as [] instead of {} in composer.json

### DIFF
--- a/src/Composer/FileSystemBasedComposerPackage.php
+++ b/src/Composer/FileSystemBasedComposerPackage.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Mezzio\Tooling\Composer;
 
+use stdClass;
+
 use function dirname;
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
+use function is_array;
 use function is_dir;
 use function is_readable;
 use function is_writable;
@@ -84,6 +87,17 @@ final class FileSystemBasedComposerPackage implements ComposerPackageInterface
 
     private function write(array $package): void
     {
+        foreach (['autoload', 'autoload-dev'] as $autoloadType) {
+            if (
+                isset($package[$autoloadType]) &&
+                isset($package[$autoloadType]['psr-4']) &&
+                is_array($package[$autoloadType]['psr-4']) &&
+                $package[$autoloadType]['psr-4'] === []
+            ) {
+                $package[$autoloadType]['psr-4'] = new stdClass();
+            }
+        }
+
         $path = dirname($this->composerFile);
         if (! is_dir($path)) {
             throw ComposerFileException::dueToMissingDirectory($path);
@@ -93,7 +107,11 @@ final class FileSystemBasedComposerPackage implements ComposerPackageInterface
             throw ComposerFileException::dueToDirectoryPermissions($path);
         }
 
-        $contents = json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $contents = json_encode(
+            $package,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+
         file_put_contents($this->composerFile, $contents . "\n");
     }
 }


### PR DESCRIPTION
Fix psr-4 empty array being serialized as [] instead of {} in composer.json

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR fixes a bug in `Mezzio\Tooling\Composer\FileSystemBasedComposerPackage` where an empty `psr-4` section in `composer.json` is being written as an empty array (`[]`), which is not valid according to Composer schema — it must be an object (`{}`).

#### Reproduce:
- Remove all dev autoload rules via tooling command
- Observe that the resulting composer.json contains:
  ```json
  "autoload-dev": {
      "psr-4": []
  }

* Composer expects:

  ```json
  "autoload-dev": {
      "psr-4": {}
  }
  ```

#### Fix:

* In `write()` method, when `psr-4` is an empty array, it is now replaced with `new \stdClass()` before `json_encode()`, ensuring correct `{}` output.

#### Why it matters:

* Composer throws schema validation warnings or errors when `psr-4` is encoded as `[]`
* Ensures correct formatting of `composer.json` and compatibility with Composer's expectations.
