### PR TITLE
Fix psr-4 empty array being serialized as [] instead of {} in composer.json

### DIFF
--- a/src/Composer/FileSystemBasedComposerPackage.php
+++ b/src/Composer/FileSystemBasedComposerPackage.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Mezzio\Tooling\Composer;
 
+use stdClass;
+
 use function dirname;
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
+use function is_array;
 use function is_dir;
 use function is_readable;
 use function is_writable;
@@ -84,6 +87,17 @@ final class FileSystemBasedComposerPackage implements ComposerPackageInterface
 
     private function write(array $package): void
     {
+        foreach (['autoload', 'autoload-dev'] as $autoloadType) {
+            if (
+                isset($package[$autoloadType]) &&
+                isset($package[$autoloadType]['psr-4']) &&
+                is_array($package[$autoloadType]['psr-4']) &&
+                $package[$autoloadType]['psr-4'] === []
+            ) {
+                $package[$autoloadType]['psr-4'] = new stdClass();
+            }
+        }
+
         $path = dirname($this->composerFile);
         if (! is_dir($path)) {
             throw ComposerFileException::dueToMissingDirectory($path);
@@ -93,7 +107,11 @@ final class FileSystemBasedComposerPackage implements ComposerPackageInterface
             throw ComposerFileException::dueToDirectoryPermissions($path);
         }
 
-        $contents = json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $contents = json_encode(
+            $package,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+
         file_put_contents($this->composerFile, $contents . "\n");
     }
 }

--- a/test/Composer/FileSystemBasedComposerPackageTest.php
+++ b/test/Composer/FileSystemBasedComposerPackageTest.php
@@ -6,6 +6,7 @@ namespace MezzioTest\Tooling\Composer;
 
 use Mezzio\Tooling\Composer\FileSystemBasedComposerPackage;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 use function copy;
 use function file_exists;
@@ -182,5 +183,21 @@ class FileSystemBasedComposerPackageTest extends TestCase
 
         $this->assertAutoloadRuleExists('TestModule', 'src/TestModule/', false, $projectRoot . '/composer.json');
         $this->assertAutoloadRuleDoesNotExist($module, false, $projectRoot . '/composer.json');
+    }
+
+    public function testEmptyPsr4ArrayIsConvertedToJsonObject(): void
+    {
+        $projectRoot  = $this->copyDistAsset('empty-psr4');
+        $composerFile = $projectRoot . '/composer.json';
+
+        $package = new FileSystemBasedComposerPackage($projectRoot);
+        $package->addPsr4AutoloadRule('Dummy', 'src/Dummy');
+        $package->removePsr4AutoloadRule('Dummy');
+
+        $json    = file_get_contents($composerFile);
+        $decoded = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertInstanceOf(stdClass::class, $decoded->{'autoload'}->{'psr-4'});
+        $this->assertInstanceOf(stdClass::class, $decoded->{'autoload-dev'}->{'psr-4'});
     }
 }

--- a/test/Composer/TestAsset/empty-psr4/.gitignore
+++ b/test/Composer/TestAsset/empty-psr4/.gitignore
@@ -1,0 +1,1 @@
+composer.json

--- a/test/Composer/TestAsset/empty-psr4/composer.json.dist
+++ b/test/Composer/TestAsset/empty-psr4/composer.json.dist
@@ -1,0 +1,7 @@
+{
+    "autoload-dev": {
+        "psr-4": {
+            "TestModule\\": "src/TestModule/"
+        }
+    }
+}


### PR DESCRIPTION
Fix psr-4 empty array being serialized as [] instead of {} in composer.json.
Added requried test code in to test folder.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR fixes a bug in `Mezzio\Tooling\Composer\FileSystemBasedComposerPackage` where an empty `psr-4` section in `composer.json` is being written as an empty array (`[]`), which is not valid according to Composer schema — it must be an object (`{}`).

#### Reproduce:
- Remove all dev autoload rules via tooling command
- Observe that the resulting composer.json contains:
  ```json
  "autoload-dev": {
      "psr-4": []
  }

* Composer expects:

  ```json
  "autoload-dev": {
      "psr-4": {}
  }
  ```

#### Fix:

* In `write()` method, when `psr-4` is an empty array, it is now replaced with `new \stdClass()` before `json_encode()`, ensuring correct `{}` output.

#### Why it matters:

* Composer throws schema validation warnings or errors when `psr-4` is encoded as `[]`
* Ensures correct formatting of `composer.json` and compatibility with Composer's expectations.
