### PR TITLE
Coding Standard Fixes for the PSR-15 Handler and Middleware class skeletons

### DIFF
--- a/src/CreateHandler/ClassSkeletons.php
+++ b/src/CreateHandler/ClassSkeletons.php
@@ -11,23 +11,23 @@ class ClassSkeletons
      */
     public const CLASS_SKELETON = <<<'EOS'
         <?php
-        
+
         declare(strict_types=1);
-        
+
         namespace %namespace%;
-        
+
         use Psr\Http\Message\ResponseInterface;
         use Psr\Http\Message\ServerRequestInterface;
         use Psr\Http\Server\RequestHandlerInterface;
-        
+
         class %class% implements RequestHandlerInterface
         {
-            public function handle(ServerRequestInterface $request) : ResponseInterface
+            public function handle(ServerRequestInterface $request): ResponseInterface
             {
                 // Create and return a response
             }
         }
-        
+
         EOS;
 
     /**
@@ -35,30 +35,30 @@ class ClassSkeletons
      */
     public const CLASS_SKELETON_WITH_TEMPLATE = <<<'EOS'
         <?php
-        
+
         declare(strict_types=1);
-        
+
         namespace %namespace%;
-        
+
         use Psr\Http\Message\ResponseInterface;
         use Psr\Http\Message\ServerRequestInterface;
         use Psr\Http\Server\RequestHandlerInterface;
         use Laminas\Diactoros\Response\HtmlResponse;
         use Mezzio\Template\TemplateRendererInterface;
-        
+
         class %class% implements RequestHandlerInterface
         {
             /**
              * @var TemplateRendererInterface
              */
             private $renderer;
-        
+
             public function __construct(TemplateRendererInterface $renderer)
             {
                 $this->renderer = $renderer;
             }
-        
-            public function handle(ServerRequestInterface $request) : ResponseInterface
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
             {
                 // Do some work...
                 // Render and return a response:
@@ -68,6 +68,6 @@ class ClassSkeletons
                 ));
             }
         }
-        
+
         EOS;
 }

--- a/src/CreateMiddleware/CreateMiddleware.php
+++ b/src/CreateMiddleware/CreateMiddleware.php
@@ -41,24 +41,24 @@ final class CreateMiddleware
      */
     public const CLASS_SKELETON = <<<'EOS'
         <?php
-        
+
         declare(strict_types=1);
-        
+
         namespace %namespace%;
-        
+
         use Psr\Http\Message\ResponseInterface;
         use Psr\Http\Message\ServerRequestInterface;
         use Psr\Http\Server\MiddlewareInterface;
         use Psr\Http\Server\RequestHandlerInterface;
-        
+
         class %class% implements MiddlewareInterface
         {
-            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
             {
                 // $response = $handler->handle($request);
             }
         }
-        
+
         EOS;
 
     // phpcs:enable

--- a/test/CreateHandler/CreateHandlerTest.php
+++ b/test/CreateHandler/CreateHandlerTest.php
@@ -138,7 +138,7 @@ class CreateHandlerTest extends TestCase
             $classFileContents
         );
         self::assertMatchesRegularExpression(
-            '#^\s{4}public function handle\(ServerRequestInterface \$request\) : ResponseInterface$#m',
+            '#^\s{4}public function handle\(ServerRequestInterface \$request\): ResponseInterface$#m',
             $classFileContents
         );
     }
@@ -171,7 +171,7 @@ class CreateHandlerTest extends TestCase
             $classFileContents
         );
         self::assertMatchesRegularExpression(
-            '#^\s{4}public function handle\(ServerRequestInterface \$request\) : ResponseInterface$#m',
+            '#^\s{4}public function handle\(ServerRequestInterface \$request\): ResponseInterface$#m',
             $classFileContents
         );
     }
@@ -204,7 +204,7 @@ class CreateHandlerTest extends TestCase
             $classFileContents
         );
         self::assertMatchesRegularExpression(
-            '#^\s{4}public function handle\(ServerRequestInterface \$request\) : ResponseInterface$#m',
+            '#^\s{4}public function handle\(ServerRequestInterface \$request\): ResponseInterface$#m',
             $classFileContents
         );
     }
@@ -237,7 +237,7 @@ class CreateHandlerTest extends TestCase
             $classFileContents
         );
         self::assertMatchesRegularExpression(
-            '#^\s{4}public function handle\(ServerRequestInterface \$request\) : ResponseInterface$#m',
+            '#^\s{4}public function handle\(ServerRequestInterface \$request\): ResponseInterface$#m',
             $classFileContents
         );
     }

--- a/test/CreateMiddleware/CreateMiddlewareTest.php
+++ b/test/CreateMiddleware/CreateMiddlewareTest.php
@@ -139,7 +139,7 @@ class CreateMiddlewareTest extends TestCase
         );
         self::assertMatchesRegularExpression(
             '#^\s{4}public function process\(ServerRequestInterface \$request,'
-                . ' RequestHandlerInterface \$handler\) : ResponseInterface$#m',
+                . ' RequestHandlerInterface \$handler\): ResponseInterface$#m',
             $classFileContents
         );
     }
@@ -173,7 +173,7 @@ class CreateMiddlewareTest extends TestCase
         );
         self::assertMatchesRegularExpression(
             '#^\s{4}public function process\(ServerRequestInterface \$request,'
-                . ' RequestHandlerInterface \$handler\) : ResponseInterface$#m',
+                . ' RequestHandlerInterface \$handler\): ResponseInterface$#m',
             $classFileContents
         );
     }
@@ -207,7 +207,7 @@ class CreateMiddlewareTest extends TestCase
         );
         self::assertMatchesRegularExpression(
             '#^\s{4}public function process\(ServerRequestInterface \$request,'
-                . ' RequestHandlerInterface \$handler\) : ResponseInterface$#m',
+                . ' RequestHandlerInterface \$handler\): ResponseInterface$#m',
             $classFileContents
         );
     }
@@ -241,7 +241,7 @@ class CreateMiddlewareTest extends TestCase
         );
         self::assertMatchesRegularExpression(
             '#^\s{4}public function process\(ServerRequestInterface \$request,'
-                . ' RequestHandlerInterface \$handler\) : ResponseInterface$#m',
+                . ' RequestHandlerInterface \$handler\): ResponseInterface$#m',
             $classFileContents
         );
     }


### PR DESCRIPTION
Update strings in the related unit test to correctly check the generated classes.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
When generating Handlers/Middleware the tooling creates classes that fail the PHPCS coding standard check due to a space between the closing ) and the : in the handle/process method signatures. This PR also updates the current unit test to match the updated strings.

Please reference the following.
https://github.com/mezzio/mezzio-tooling/blob/6debf20c01fa7ad03b318312416370c0516913d2/src/CreateHandler/ClassSkeletons.php#L25

https://github.com/mezzio/mezzio-tooling/blob/6debf20c01fa7ad03b318312416370c0516913d2/src/CreateHandler/ClassSkeletons.php#L61

https://github.com/mezzio/mezzio-tooling/blob/6debf20c01fa7ad03b318312416370c0516913d2/src/CreateMiddleware/CreateMiddleware.php#L56
